### PR TITLE
Major: Rewrote loop to leaf-wise

### DIFF
--- a/LIB/INDICATORS/coarseningIndicator_block.f90
+++ b/LIB/INDICATORS/coarseningIndicator_block.f90
@@ -107,7 +107,7 @@ subroutine coarseningIndicator_block( params, block_data, block_work, indicator,
         call threshold_block( params, block_data, thresholding_component, refinement_status, norm, level, input_is_WD, indices=idx)
 
         ! timing for debugging - block based so should not be deployed for productive versions
-        ! call toc( "coarseningIndicator_block (treshold_block)", MPI_Wtime()-t0 )
+        ! call toc( "coarseningIndicator_block (treshold_block)", 1000, MPI_Wtime()-t0 )
     case default
         call abort(151413,"ERROR: unknown coarsening operator: "//trim(adjustl(indicator)))
 
@@ -164,7 +164,7 @@ subroutine coarseningIndicator_block( params, block_data, block_work, indicator,
         refinement_status = max(refinement_status, refinement_status_mask)
 
         ! timing for debugging - block based so should not be deployed for productive versions
-        ! call toc( "coarseningIndicator_block (mask_comp)", MPI_Wtime()-t0 )
+        ! call toc( "coarseningIndicator_block (mask_comp)", 1001, MPI_Wtime()-t0 )
     endif
 
 end subroutine coarseningIndicator_block

--- a/LIB/INI/setInitialCondition_tree.f90
+++ b/LIB/INI/setInitialCondition_tree.f90
@@ -66,7 +66,7 @@ subroutine setInitialCondition_tree(params, hvy_block, tree_ID, adapt, time, ite
         call updateMetadata_tree(params, tree_ID)
 
         ! synching is required for the adaptation step
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+        call sync_ghosts_tree( params, hvy_block, tree_ID )
 
         ! even if we read the initial condition from file, we can still adapt it immediately
         ! so the max error is eps. This is useful if we read a dense field where we already know that
@@ -231,7 +231,7 @@ subroutine setInitialCondition_tree(params, hvy_block, tree_ID, adapt, time, ite
 
     ! synchronize ghosts now, in order to start with a clean grid. NOTE this can actually be removed, but
     ! it is a safety issue. Better simply keep it.
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     call MPI_barrier(WABBIT_COMM, k)
 

--- a/LIB/IO/save_data.f90
+++ b/LIB/IO/save_data.f90
@@ -34,7 +34,7 @@ subroutine save_data(iteration, time, params, hvy_block, hvy_tmp, hvy_mask, tree
     n_domain = 0
 
     ! we need to sync ghost nodes in order to compute the vorticity, if it is used and stored.
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 
     ! create mask function at current time. (this routine is rarely called and thus
     ! the overhead of calling createMask_tree if the mask is not stored is supposed
@@ -45,7 +45,7 @@ subroutine save_data(iteration, time, params, hvy_block, hvy_tmp, hvy_mask, tree
     ! any saved file must be sync'ed, because we store
     ! the 1st ghost node for visualization.
     if (params%penalization) then
-        call sync_ghosts_all( params, lgt_block, hvy_mask, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+        call sync_ghosts_tree( params, hvy_mask, tree_ID_flow )
     endif
 
 
@@ -78,7 +78,7 @@ subroutine save_data(iteration, time, params, hvy_block, hvy_tmp, hvy_mask, tree
 
     ! uniqueGrid modification:
     ! any saved file must be sync'ed, because we store the 1st ghost node for visualization.
-    call sync_ghosts_all( params, lgt_block, hvy_tmp(:,:,:,1:params%N_fields_saved,:), hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+    call sync_ghosts_tree( params, hvy_tmp(:,:,:,1:params%N_fields_saved,:), tree_ID_flow )
 
 
     ! actual saving step. one file per component.

--- a/LIB/IO/save_data.f90
+++ b/LIB/IO/save_data.f90
@@ -99,5 +99,5 @@ subroutine save_data(iteration, time, params, hvy_block, hvy_tmp, hvy_mask, tree
         call saveHDF5_tree( fname, time, iteration, k, params, hvy_tmp, tree_ID)
     enddo
 
-    call toc( "save_data", MPI_wtime()-t0 )
+    call toc( "TOPLEVEL: save_data", 15, MPI_wtime()-t0 )
 end subroutine save_data

--- a/LIB/MAIN/main.f90
+++ b/LIB/MAIN/main.f90
@@ -201,7 +201,7 @@ program main
 
 
     ! timing
-    call toc( "init_data", MPI_wtime()-sub_t0 )
+    call toc( "TOPLEVEL: init_data", 14, MPI_wtime()-sub_t0 )
 
     !---------------------------------------------------------------------------
     ! main time loop
@@ -250,7 +250,7 @@ program main
             ! refine the mesh
             call refine_tree( params, hvy_block, hvy_tmp, "everywhere", tree_ID=tree_ID_flow )
         endif
-        call toc( "TOPLEVEL: refinement", MPI_wtime()-t4)
+        call toc( "TOPLEVEL: refinement", 10, MPI_wtime()-t4)
         Nblocks_rhs = lgt_n(tree_ID_flow)
 
         Jmin1 = minActiveLevel_tree(tree_ID_flow)
@@ -270,7 +270,7 @@ program main
             !*******************************************************************
             t4 = MPI_wtime()
             call timeStep_tree( time, dt, iteration, params, hvy_block, hvy_work, hvy_mask, hvy_tmp, tree_ID_flow )
-            call toc( "TOPLEVEL: time stepper", MPI_wtime()-t4)
+            call toc( "TOPLEVEL: time stepper", 11, MPI_wtime()-t4)
 
             ! determine if it is time to save data
             it_is_time_to_save_data = .false.
@@ -303,7 +303,7 @@ program main
                     call filter_wrapper(time, params, hvy_block, hvy_tmp, hvy_mask, tree_ID_flow)
                 end if
             end if
-            call toc( "TOPLEVEL: filter", MPI_wtime()-t4)
+            call toc( "TOPLEVEL: filter", 12, MPI_wtime()-t4)
 
             !*******************************************************************
             ! statistics
@@ -342,7 +342,7 @@ program main
                 call adapt_tree( time, params, hvy_block, tree_ID_flow, params%coarsening_indicator, hvy_tmp)
             endif
         endif
-        call toc( "TOPLEVEL: adapt mesh", MPI_wtime()-t4)
+        call toc( "TOPLEVEL: adapt mesh", 13, MPI_wtime()-t4)
         Nblocks = lgt_n(tree_ID_flow)
 
         !***********************************************************************
@@ -440,7 +440,8 @@ program main
     call MPI_Barrier(WABBIT_COMM, ierr)
 
     ! make a summary of the program parts, which have been profiled using toc(...)
-    ! and print it to stdout
+    ! and print it to stdout, safe total time just before to insert it as well
+    call toc( "TOPLEVEL: TOTAL", 9, MPI_wtime()-t0)
     call summarize_profiling( WABBIT_COMM )
 
     call deallocate_forest(params, hvy_block, hvy_work, hvy_tmp)

--- a/LIB/MESH/InputOutput.f90
+++ b/LIB/MESH/InputOutput.f90
@@ -45,8 +45,7 @@ subroutine saveHDF5_tree(fname, time, iteration, dF, params, hvy_block, tree_ID,
     ! uniqueGrid modification
     if (.not. no_sync2) then
         ! because when saving pruned trees, sync is not possible...
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, &
-        hvy_active(:,tree_ID), hvy_n(tree_ID) )
+        call sync_ghosts_tree( params, hvy_block, tree_ID )
     endif
     Jmin_active = minActiveLevel_tree(tree_ID)
     Jmax_active = maxActiveLevel_tree(tree_ID)
@@ -658,10 +657,10 @@ subroutine readHDF5vct_tree(fnames, params, hvy_block, tree_ID, time, iteration,
 
     if (present(synchronize_ghosts)) then
         if (synchronize_ghosts) then
-            call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+            call sync_ghosts_tree(params, hvy_block, tree_ID )
         endif
     else
-        call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+        call sync_ghosts_tree(params, hvy_block, tree_ID )
     endif
 
     ! it is useful to print out the information on active levels in the file
@@ -948,6 +947,6 @@ subroutine read_field2tree(params, fnames, N_files, tree_ID, hvy_block, verbosit
     call createActiveSortedLists_forest(params)
     call updateNeighbors_tree(params, tree_ID)
 
-    call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree(params, hvy_block, tree_ID )
 
 end subroutine read_field2tree

--- a/LIB/MESH/adapt_tree.f90
+++ b/LIB/MESH/adapt_tree.f90
@@ -81,7 +81,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
     ! we synchronize them.
     t0 = MPI_Wtime()
     call updateMetadata_tree(params, tree_ID)
-    call toc( "adapt_tree (update neighbors)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (update metadata)", 101, MPI_Wtime()-t0 )
 
     ! Wavelet decomposition can be done for each block individually
     ! We iterate leaf-wise, meaning that each block is investigated and coarsened and resulting new blocks are then investigated
@@ -97,7 +97,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         lgt_ID = lgt_active(k, tree_ID)
         lgt_block(lgt_ID, IDX_REFINE_STS) = REF_TMP_UNTREATED            
     end do
-    call toc( "adapt_tree (temp flag)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (temp flag)", 102, MPI_Wtime()-t0 )
 
     do while (iterate)
         lgt_n_old = lgt_n(tree_ID)
@@ -123,7 +123,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         g_this = max(ubound(params%HD,1),ubound(params%GD,1))
         call sync_TMP_from_MF( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID), hvy_n(tree_ID), &
             REF_TMP_UNTREATED, g_minus=g_this, g_plus=g_this, hvy_tmp=hvy_tmp)
-        call toc( "adapt_tree (sync lvl <- MF)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (sync lvl <- MF)", 103, MPI_Wtime()-t0 )
 
 
         ! Wavelet-transform all blocks on this level
@@ -154,7 +154,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
                 endif
             endif
         end do
-        call toc( "adapt_tree (FWT)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (FWT)", 104, MPI_Wtime()-t0 )
 
 
         ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -167,7 +167,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
             call coarse_extension_modify_tree(params, lgt_block, hvy_block, hvy_tmp, hvy_neighbor, hvy_active(:,tree_ID), &
             hvy_n(tree_ID), lgt_n(tree_ID), tree_ID)
         endif
-        call toc( "adapt_tree (coarse_extension_modify)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (coarse_extension_modify)", 105, MPI_Wtime()-t0 )
 
 
         !> coarseningIndicator_tree resets ALL refinement_status to 0 (all blocks, not only level)
@@ -188,7 +188,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
             call coarseningIndicator_tree( time, params, level, hvy_block, hvy_tmp, tree_ID, indicator, iteration, &
                 ignore_maxlevel=ignore_maxlevel2, input_is_WD=.true., check_ref_TMP=.true.)
         endif
-        call toc( "adapt_tree (coarseningIndicator_tree)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (coarseningIndicator_tree)", 106, MPI_Wtime()-t0 )
 
         ! After coarseningIndicator_tree, the situation is:
         ! coarseningIndicator_tree works on LEVEL (for wavelet cases).
@@ -204,7 +204,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         !         ! does not make much sense, but for development...)
         !         t0 = MPI_Wtime()
         !         call addSecurityZone_level( time, params, level, tree_ID, hvy_block, hvy_tmp )
-        !         call toc( "adapt_tree (addSecurityZone_level)", MPI_Wtime()-t0 )
+        !         call toc( "adapt_tree (addSecurityZone_level)", 107, MPI_Wtime()-t0 )
         !     endif
         ! endif
         ! ! In addSecurityZone_tree, some blocks on level J have revoked their -1 status to 0, some
@@ -218,24 +218,24 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         if (ignore_maxlevel2 .eqv. .false.) then
             call respectJmaxJmin_tree( params, tree_ID )
         endif
-        call toc( "adapt_tree (respectJmaxJmin_tree)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (respectJmaxJmin_tree)", 108, MPI_Wtime()-t0 )
 
         ! unmark blocks that cannot be coarsened due to gradedness and completeness
         t0 = MPI_Wtime()
         call ensureGradedness_tree( params, tree_ID, mark_TMP_flag=.true. )
-        call toc( "adapt_tree (ensureGradedness_tree)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (ensureGradedness_tree)", 109, MPI_Wtime()-t0 )
 
         ! Adapt the mesh, i.e. actually merge blocks
         ! This uses the already wavelet decomposed blocks and coarsens them by effectively copying their SC into the new mother block
         t0 = MPI_Wtime()
         call executeCoarsening_WD_tree( params, hvy_block, tree_ID, mark_TMP_flag=.true.)
-        call toc( "adapt_tree (executeCoarsening_level)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (executeCoarsening_level)", 110, MPI_Wtime()-t0 )
 
         ! update grid lists: active list, neighbor relations, etc
         ! JB: Why is this not in executeCoarsening? This might make more sense
         t0 = MPI_Wtime()
         call updateMetadata_tree(params, tree_ID)
-        call toc( "adapt_tree (update metadata)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (update metadata)", 101, MPI_Wtime()-t0 )
 
         ! iteration counter
         iteration = iteration + 1
@@ -255,7 +255,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         call coarse_extension_modify_tree(params, lgt_block, hvy_block, hvy_tmp, hvy_neighbor, hvy_active(:,tree_ID), &
         hvy_n(tree_ID), lgt_n(tree_ID), tree_ID)
     endif
-    call toc( "adapt_tree (coarse_extension_modify)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (coarse_extension_modify)", 105, MPI_Wtime()-t0 )
 
 
     ! synch SC and WC from new coarser neighbours and same-level neighbours in order to apply the correct wavelet reconstruction
@@ -265,7 +265,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
     call sync_SCWC_from_MC( params, lgt_block, hvy_block, hvy_neighbor, &
     hvy_active(:, tree_ID), hvy_n(tree_ID), hvy_tmp, g_minus=g_spaghetti, g_plus=g_spaghetti)
 
-    call toc( "adapt_tree (sync all <- MC)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (sync all <- MC)", 112, MPI_Wtime()-t0 )
 
 
     ! After synching with coarser neighbors, the spaghetti form of the whole ghost patch is filled with values
@@ -277,7 +277,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         call coarse_extension_modify_tree(params, lgt_block, hvy_block, hvy_tmp, hvy_neighbor, hvy_active(:,tree_ID), &
         hvy_n(tree_ID), lgt_n(tree_ID), tree_ID, sc_skip_ghosts=.true.)
     endif
-    call toc( "adapt_tree (coarse_extension_modify)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (coarse_extension_modify)", 105, MPI_Wtime()-t0 )
 
 
     ! Wavelet-reconstruct all blocks in one go
@@ -292,13 +292,13 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
             hvy_block(:,:,:,1:size(hvy_block, 4),hvy_ID) = hvy_tmp(:,:,:,1:size(hvy_block, 4),hvy_ID)
         end do
     endif
-    call toc( "adapt_tree (RWT)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (RWT)", 113, MPI_Wtime()-t0 )
 
     ! synchronize ghost nodes - final synch to update all neighbours with the new values
     ! Just once here at the end after reconstruct so everything is in order
     t0 = MPI_Wtime()
     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
-    call toc( "adapt_tree (sync post)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (sync post)", 114, MPI_Wtime()-t0 )
 
 
     ! At this point the coarsening is done. All blocks that can be coarsened are coarsened
@@ -306,9 +306,9 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
     ! be balanced, so we have to balance load now
     t0 = MPI_Wtime()
     call balanceLoad_tree( params, hvy_block, tree_ID )
-    call toc( "adapt_tree (balanceLoad_tree)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (balanceLoad_tree)", 115, MPI_Wtime()-t0 )
 
-    call toc( "adapt_tree (TOTAL)", MPI_wtime()-t1)
+    call toc( "adapt_tree (TOTAL)", 100, MPI_wtime()-t1)
 end subroutine
 
 
@@ -382,7 +382,7 @@ subroutine adapt_tree_cvs( time, params, hvy_block, tree_ID, indicator, hvy_tmp,
     ! we synchronize them.
     t0 = MPI_Wtime()
     call updateMetadata_tree(params, tree_ID)
-    call toc( "adapt_tree (update neighbors)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (update metadata)", 101, MPI_Wtime()-t0 )
 
     !***********************************************************************
     ! Wavelet decomposition - iterate from finest level (Jmax) to coarsest (JMin)
@@ -400,7 +400,7 @@ subroutine adapt_tree_cvs( time, params, hvy_block, tree_ID, indicator, hvy_tmp,
         t0 = MPI_Wtime()
         g_this = max(ubound(params%HD,1),ubound(params%GD,1))
         call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID), hvy_n(tree_ID), g_minus=g_this, g_plus=g_this)
-        call toc( "adapt_tree (sync_WD_pre)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (sync_WD_pre)", 102, MPI_Wtime()-t0 )
 
         ! Wavelet decomposition
         t0 = MPI_Wtime()
@@ -421,111 +421,23 @@ subroutine adapt_tree_cvs( time, params, hvy_block, tree_ID, indicator, hvy_tmp,
                 call waveletDecomposition_block(params, hvy_block(:,:,:,1:nc,hvyID))
             endif
         end do
-        call toc( "adata_tree (FWT)", MPI_Wtime()-t0 )
+        call toc( "adata_tree (FWT)", 103, MPI_Wtime()-t0 )
 
         ! Synch SC to mother blocks, create this block if not present
         t0 = MPI_Wtime()
         g_this = max(ubound(params%HD,1),ubound(params%GD,1))
         call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID), hvy_n(tree_ID), g_minus=g_this, g_plus=g_this)
-        call toc( "adapt_tree (sync_SC2Mother)", MPI_Wtime()-t0 )
+        call toc( "adapt_tree (sync_SC2Mother)", 104, MPI_Wtime()-t0 )
     end do
 
-
-    !     !> coarseningIndicator_tree resets ALL refinement_status to 0 (all blocks, not only level)
-    !     ! Check the entire grid where to coarsen. Note this is a wrapper for coarseningIndicator_block, which
-    !     ! acts on a single block only.
-    !     ! We distinguish two cases: wavelet or no wavelet (Shakespeare!). The wavelet case is the default, other indicators
-    !     ! are used mostly for testing.
-    !     ! The routine first sets all blocks (regardless of level) to 0 (STAY).
-    !     ! In the wavelet case, we check the blocks for their largest detail (=wavelet coeff). If the coarseExtension is used,
-    !     ! the FWT of all blocks (on this level) is performed there (even for blocks that are not modified) - this reduces load
-    !     ! imbalancing. If coarseExtension is not used, the actual FWT of blocks (on this level) is performed in coarseningIndicator_tree.
-    !     ! The routine assigns -1 (COARSEN) to a block, if it matches the criterion. This status may however be revoked below.
-    !     t0 = MPI_Wtime()
-    !     if (present(hvy_mask)) then
-    !         ! if present, the mask can also be used for thresholding (and not only the state vector). However,
-    !         ! as the grid changes within this routine, the mask will have to be constructed in coarseningIndicator_tree
-    !         call coarseningIndicator_tree( time, params, level, hvy_block, hvy_tmp, tree_ID, indicator, iteration, ignore_maxlevel2, hvy_mask)
-    !     else
-    !         call coarseningIndicator_tree( time, params, level, hvy_block, hvy_tmp, tree_ID, indicator, iteration, ignore_maxlevel2)
-    !     endif
-    !     call toc( "adapt_tree (coarseningIndicator_tree)", MPI_Wtime()-t0 )
-
-    !     ! After coarseningIndicator_tree, the situation is:
-    !     ! coarseningIndicator_tree works on LEVEL.
-    !     ! blocks that are significant on that level now have status 0, others (on this level) have -1
-    !     ! Any blocks on other levels have status 0.
-
-    !     ! here, we should refine the coarse frontier blocks
-
-    !     ! afterwards, the newly created blocks should have status 0 (check that!!)
-    !     ! can we call refinement if the refinement_status incudes "-1" ? ===> to be checked.
-
-    !     if (params%useSecurityZone) then
-    !         if ((indicator=="threshold-state-vector") .or. (indicator=="primary-variables")) then
-    !             ! Note: we can add the security zone also for non-lifted wavelets (although this 
-    !             ! does not make much sense, but for development...)
-    !             call addSecurityZone_tree( time, params, level, tree_ID, hvy_block, hvy_tmp )
-    !         endif
-    !     endif
-
-    !     ! In addSecurityZone_tree, some blocks on level J have revoked their -1 status to 0, some
-    !     ! new blocks may have been created and they have the status 0 as well.
-    !     ! Note: as the algorithm proceeds level-wise, a block on level J is not checked again - it
-    !     ! is not possible to 'accidentally' delete the newly created blocks later on.
-
-
-    !     ! check if block has reached maximal level, if so, remove refinement flags
-    !     t0 = MPI_Wtime()
-    !     if (ignore_maxlevel2 .eqv. .false.) then
-    !         call respectJmaxJmin_tree( params, tree_ID )
-    !     endif
-    !     call toc( "adapt_tree (respectJmaxJmin_tree)", MPI_Wtime()-t0 )
-
-    !     ! unmark blocks that cannot be coarsened due to gradedness and completeness
-    !     t0 = MPI_Wtime()
-    !     call ensureGradedness_tree( params, tree_ID )
-    !     call toc( "adapt_tree (ensureGradedness_tree)", MPI_Wtime()-t0 )
-
-    !     ! adapt the mesh, i.e. actually merge blocks
-    !     ! this applies the wavelet low-pass filter as well (h*h) before decimation
-    !     t0 = MPI_Wtime()
-    !     call executeCoarsening_tree( params, hvy_block, tree_ID )
-    !     call toc( "adapt_tree (executeCoarsening_tree)", MPI_Wtime()-t0 )
-
-    !     ! update grid lists: active list, neighbor relations, etc
-    !     t0 = MPI_Wtime()
-    !     call updateMetadata_tree(params, tree_ID)
-    !     call toc( "adapt_tree (update neighbors)", MPI_Wtime()-t0 )
-
-    !     ! After the coarsening step on this level, the some blocks were (possibly) coarsened.
-    !     ! If that happened (and it is the usual case), suddenly new blocks have coarser neighbors, and
-    !     ! on those, the coarseExt needs to be done. Note performing the coarseExt twice on a block does not
-    !     ! alter the data, but is of course not for free. The usual workflow in adapt_tree is that many blocks
-    !     ! can be coarsened, and thus the 2nd call to coarseExtensionUpdate_level is much cheaper.
-    !     t0 = MPI_Wtime()
-    !     if (params%useCoarseExtension) then
-    !         call coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_tmp, hvy_neighbor, hvy_active(:,tree_ID), &
-    !         hvy_n(tree_ID),lgt_n(tree_ID), inputDataSynced=.false., level=level, hvy_details=hvy_details )
-    !     endif
-    !     call toc( "adapt_tree (coarse_extension2)", MPI_Wtime()-t0 )
-
-    !     ! iteration counter (used for random coarsening criterion)
-    !     iteration = iteration + 1
-    !     level = level - 1
-    !     ! loop continues until we are on the lowest level.
-    !     iterate = (level >= Jmin)
-    !     ! if at Jmin_active nothing happens anymore, then we can escape the loop now.
-    !     if ((level <= Jmin_active).and.(lgt_n(tree_ID)==lgt_n_old)) iterate = .false.
-    ! end do
 
     ! At this point the coarsening is done. All blocks that can be coarsened are coarsened
     ! they may have passed several level also. Now, the distribution of blocks may no longer
     ! be balanced, so we have to balance load now
     t0 = MPI_Wtime()
     call balanceLoad_tree( params, hvy_block, tree_ID )
-    call toc( "adapt_tree (balanceLoad_tree)", MPI_Wtime()-t0 )
+    call toc( "adapt_tree (balanceLoad_tree)", 105, MPI_Wtime()-t0 )
 
 
-    call toc( "adapt_tree (TOTAL)", MPI_wtime()-t1)
+    call toc( "adapt_tree (TOTAL)", 100, MPI_wtime()-t1)
 end subroutine

--- a/LIB/MESH/adapt_tree.f90
+++ b/LIB/MESH/adapt_tree.f90
@@ -383,6 +383,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
     ! At this point the coarsening is done. All blocks that can be coarsened are coarsened
     ! they may have passed several level also. Now, the distribution of blocks may no longer
     ! be balanced, so we have to balance load now
+    ! ToDo: Put balanceLoad directly after loop, implement version that does not copy ghost points as we sync afterwards anyways
     t0 = MPI_Wtime()
     call balanceLoad_tree( params, hvy_block, tree_ID )
     call toc( "adapt_tree (balanceLoad_tree)", 115, MPI_Wtime()-t0 )

--- a/LIB/MESH/balanceLoad_tree.f90
+++ b/LIB/MESH/balanceLoad_tree.f90
@@ -148,7 +148,7 @@ subroutine balanceLoad_tree( params, hvy_block, tree_ID, predictable_dist)
     if (lgt_n(tree_ID) > 1) then
         call quicksort(sfc_sorted_list, 1, lgt_n(tree_ID), 3)
     end if
-    call toc( "balanceLoad_tree (SFC+sort)", MPI_wtime()-t1 )
+    call toc( "balanceLoad_tree (SFC+sort)", 91, MPI_wtime()-t1 )
 
     !---------------------------------------------------------------------------------
     ! 2nd: plan communication (fill list of blocks to transfer)
@@ -217,7 +217,7 @@ subroutine balanceLoad_tree( params, hvy_block, tree_ID, predictable_dist)
     !---------------------------------------------------------------------------------
     call block_xfer( params, sfc_com_list(1:3, 1:com_i), com_i, hvy_block, msg="balanceLoad_tree" )
 
-    call toc( "balanceLoad_tree (comm)", MPI_wtime()-t1 )
+    call toc( "balanceLoad_tree (comm)", 92, MPI_wtime()-t1 )
 
     ! the block xfer changes the light data, and afterwards active lists are outdated.
     ! NOTE: an idea would be to also xfer the neighboring information (to save the updateNeighbors_tree
@@ -226,5 +226,5 @@ subroutine balanceLoad_tree( params, hvy_block, tree_ID, predictable_dist)
     call updateMetadata_tree(params, tree_ID)
 
     ! timing
-    call toc( "balanceLoad_tree (TOTAL)", MPI_wtime()-t0 )
+    call toc( "balanceLoad_tree (TOTAL)", 90, MPI_wtime()-t0 )
 end subroutine balanceLoad_tree

--- a/LIB/MESH/coarseExtensionUpdate_tree.f90
+++ b/LIB/MESH/coarseExtensionUpdate_tree.f90
@@ -1,4 +1,8 @@
-subroutine coarseExtensionUpdate_tree( params, hvy_block, hvy_tmp, tree_ID )
+
+!> \brief do coarse extensions for all coarse-fine interfaces on a block
+!> This is very similar to adapt_tree but only affects blocks on coarse-fine interfaces and does not need to loop
+!  !!! ATTENTION !!! This routine is finished but has not been cross-checked yet
+subroutine coarseExtensionUpdate_tree( params, hvy_block, hvy_tmp, tree_ID, input_is_synced)
     ! it is not technically required to include the module here, but for VS code it reduces the number of wrong "errors"
     use module_params
 
@@ -8,15 +12,163 @@ subroutine coarseExtensionUpdate_tree( params, hvy_block, hvy_tmp, tree_ID )
     real(kind=rk), intent(inout)        :: hvy_block(:, :, :, :, :)
     real(kind=rk), intent(inout)        :: hvy_tmp(:, :, :, :, :)
     integer(kind=ik), intent(in)        :: tree_ID
+    logical, intent(in), optional       :: input_is_synced   !< in case input data was already synced we can pass this here
 
-    integer(kind=ik)                    :: Jmax_active, Jmin_active, level
+    real(kind=rk)                       :: t0, t1
+    integer(kind=ik)                    :: k_b, k_n, g_spaghetti, g_this, REF_TMP, lgtID_neighbor, level_neighbor, ref_neighbor, hvyID, lgtID, level_me, ref_me
+    logical                             :: inputIsSynced
 
-    Jmin_active = minActiveLevel_tree(tree_ID)
-    Jmax_active = maxActiveLevel_tree(tree_ID)
+    t0          = MPI_Wtime()
+    t1          = MPI_Wtime()
+    REF_TMP = 197
 
-    do level = Jmax_active, Jmin_active, -1
-        call coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_tmp, hvy_neighbor, hvy_active(:,tree_ID), &
-        hvy_n(tree_ID),lgt_n(tree_ID), inputDataSynced=.false., level=level)
-    enddo
+    ! it turns out, when the coefficients are spaghetti-ordered,
+    ! we can sync only even numbers of points and save one for odd numbered
+    g_spaghetti = params%g/2*2
+
+    inputIsSynced = .false.
+    if (present(input_is_synced)) inputIsSynced = input_is_synced
+
+
+    ! To avoid that the incoming hvy_neighbor array and active lists are outdated
+    ! we synchronize them.
+    t0 = MPI_Wtime()
+    call updateMetadata_tree(params, tree_ID)
+    call toc( "coarseExntesionsUpdate_tree (update metadata)", 151, MPI_Wtime()-t0 )
+
+    ! mark all blocks where to apply coarse-extension
+    t0 = MPI_Wtime()
+    do k_b = 1, hvy_n(tree_ID)
+        hvyID = hvy_active(k_b, tree_ID)
+        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
+        level_me       = lgt_block( lgtID, IDX_MESH_LVL )
+
+        ! check if this block is to be modified
+        do k_n = 1, size(hvy_neighbor, 2)
+            ! neighbor exists ?
+            if ( hvy_neighbor(hvyID, k_n) /= -1 ) then
+                ! neighbor light data id
+                lgtID_neighbor = hvy_neighbor( hvyID, k_n )
+                level_neighbor = lgt_block( lgtID_neighbor, IDX_MESH_LVL )
+
+                ! we proceed level-wise
+                if ((level_neighbor < level_me)) then
+                    lgt_block(lgtID, IDX_REFINE_STS) = REF_TMP_UNTREATED
+                    exit
+                endif
+            endif
+        enddo
+    end do
+
+    ! we also need to wavelet decompose all neighbors of affected blocks so that we can sync the SC and WC
+    ! in theory some are not needed (far off the interface) but this is not implemented currently
+    call synchronize_lgt_data( params, refinement_status_only=.true. )
+    do k_b = 1, hvy_n(tree_ID)
+        hvyID = hvy_active(k_b, tree_ID)
+        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
+        level_me       = lgt_block( lgtID, IDX_MESH_LVL )
+
+        ! check if neighbor wants to coarse, set temporary flag
+        do k_n = 1, size(hvy_neighbor, 2)
+            ! neighbor exists ?
+            lgtID_neighbor = hvy_neighbor( hvyID, k_n )
+            if ( lgtID_neighbor /= -1 ) then
+                ! neighbor light data id
+                ref_neighbor = lgt_block( lgtID_neighbor, IDX_REFINE_STS )
+
+                ! we proceed level-wise
+                if (ref_neighbor == REF_TMP_UNTREATED) then
+                    lgt_block(lgtID, IDX_REFINE_STS) = REF_TMP
+                    exit
+                endif
+            endif
+        enddo
+    end do
+    ! change temporary flag to temporary untreated flag
+    do k_b = 1, hvy_n(tree_ID)
+        hvyID = hvy_active(k_b, tree_ID)
+        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
+        ref_me       = lgt_block( lgtID, IDX_REFINE_STS )
+
+        if (ref_me == REF_TMP) lgt_block( lgtID, IDX_REFINE_STS ) = REF_TMP_UNTREATED
+    end do
+    ! one more sync so that all ref flags are everywhere, probably this one is not needed anymore but lets keep it clean
+    call synchronize_lgt_data( params, refinement_status_only=.true. )
+
+    call toc( "coarseExtensionUpdate_tree (temp flag)", 152, MPI_Wtime()-t0 )
+
+    ! sync values to blocks that want to wavelet decompose
+    if (.not. inputIsSynced) then
+        t0 = MPI_Wtime()
+        g_this = max(ubound(params%HD,1),ubound(params%GD,1))
+        call sync_TMP_from_MF( params, hvy_block, tree_ID, REF_TMP_UNTREATED, g_minus=g_this, g_plus=g_this, hvy_tmp=hvy_tmp)
+        call toc( "coarseExtensionUpdate_tree (sync lvl <- MF)", 153, MPI_Wtime()-t0 )
+    endif
+
+    ! Wavelet-transform all blocks on this level
+    ! From now on until wavelet retransform hvy_block will hold the wavelet decomposed values in spaghetti form for affected blocks
+    t0 = MPI_Wtime()
+    do k_b = 1, hvy_n(tree_ID)
+        hvyID = hvy_active(k_b, tree_ID)
+
+        ! We compute detail coefficients on the fly here, for all blocks
+        ! on the level.
+        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
+        ref_me = lgt_block( lgtID, IDX_REFINE_STS )
+
+        ! FWT required for a block that is on the level
+        if (ref_me == REF_TMP_UNTREATED) then
+            ! hvy_tmp now is a copy with sync'ed ghost points.
+            hvy_tmp(:,:,:,1:size(hvy_block, 4),hvyID) = hvy_block(:,:,:,1:size(hvy_block, 4),hvyID)
+            level_me = lgt_block( lgtID, IDX_MESH_LVL )
+
+            ! Compute wavelet decomposition
+            call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
+        endif
+    end do
+    call toc( "coarseExtensionUpdate_tree (FWT)", 154, MPI_Wtime()-t0 )
+
+    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ! coarseExtension: remove wavelet coefficients near a fine/coarse interface
+    ! on the fine block. Does nothing in the case of CDF60, CDF40 or CDF20.
+    ! This is the first coarse extension before removing blocks
+    ! As every block is assumed to be WDed here we can do it on the whole tree
+    t0 = MPI_Wtime()
+    if (params%useCoarseExtension .and. params%isLiftedWavelet) then
+        call coarse_extension_modify_tree(params, hvy_block, hvy_tmp, tree_ID)
+    endif
+    call toc( "coarseExtensionUpdate_tree (coarse_extension_modify)", 155, MPI_Wtime()-t0 )
+
+    ! synch SC and WC from new coarser neighbours and same-level neighbours in order to apply the correct wavelet reconstruction
+    ! Attention1: For finer neighbours this is not possible, so near fine interfaces we cannot reconstruct correct values.
+    ! Attention2: This uses hvy_temp for coarser neighbors to predict the data, as we want the correct SC from coarser neighbors
+    ! Attention3: Neighboring blocks have fulfilled their role already so what they sync is not important, we could skip it but do it anyways for now
+    t0 = MPI_Wtime()
+    call sync_SCWC_from_MC( params, hvy_block, tree_ID, hvy_tmp, g_minus=g_spaghetti, g_plus=g_spaghetti)
+    call toc( "coarseExtensionUpdate_tree (sync all <- MC)", 156, MPI_Wtime()-t0 )
+
+    ! After synching with coarser neighbors, the spaghetti form of the whole ghost patch is filled with values
+    ! We now need to delete all values in spots of WC, leaving only the correct SC values from coarse neighbours
+    ! This uses the fact that values refined on the coarse grid points with wc=0 are the copied SC values
+    ! We do this in order tu bundle up the synchronizations in the step before as the modification is really cheap
+    t0 = MPI_Wtime()
+    if (params%useCoarseExtension .and. params%isLiftedWavelet) then
+        call coarse_extension_modify_tree(params, hvy_block, hvy_tmp, tree_ID, sc_skip_ghosts=.true.)
+    endif
+    call toc( "coarseExtensionUpdate_tree (coarse_extension_modify)", 155, MPI_Wtime()-t0 )
+
+    ! Wavelet-reconstruct blocks
+    ! Copy back old values if no coarse extension is applied and elsewise just overwrite the affected patches inside the domain
+    t0 = MPI_Wtime()
+    call coarse_extension_reconstruct_tree(params, hvy_block, hvy_tmp, tree_ID, REF_TMP_CHECK=REF_TMP_UNTREATED)
+    call toc( "coarseExtensionUpdate_tree (RWT)", 157, MPI_Wtime()-t0 )
+
+    ! synchronize ghost nodes - final synch to update all neighbours with the new values
+    ! Just once here at the end after reconstruct so everything is in order
+    t0 = MPI_Wtime()
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
+    call toc( "coarseExtensionUpdate_tree (sync post)", 158, MPI_Wtime()-t0 )
+
+    call toc( "coarseExtensionUpdate_tree (TOTAL)", 150, MPI_wtime()-t1)
 
 end subroutine

--- a/LIB/MESH/coarseningIndicator_tree.f90
+++ b/LIB/MESH/coarseningIndicator_tree.f90
@@ -87,7 +87,7 @@ subroutine coarseningIndicator_tree( time, params, level_this, hvy_block, hvy_tm
         ! work as designed, but use it carefully, as it is still developped. If the PARAMS file sets
         ! params%dont_use_pruned_tree_mask=1, it is deactivated anyways.
         call createMask_tree(params, time, hvy_mask, hvy_tmp, all_parts=.false.)
-        call toc( "coarseningIndicator (createMask_tree)", MPI_Wtime()-t0 )
+        call toc( "coarseningIndicator (createMask_tree)", 120, MPI_Wtime()-t0 )
     endif
 
 
@@ -137,7 +137,7 @@ subroutine coarseningIndicator_tree( time, params, level_this, hvy_block, hvy_tm
         ! if (params%threshold_mask .and. N_thresholding_components /= params%n_eqn) &
         ! call abort(2801191,"your thresholding does not work with threshold-mask.")
 
-        ! call toc( "coarseningIndicator (prepare thresholdfield)", MPI_Wtime()-t0 )
+        ! call toc( "coarseningIndicator (prepare thresholdfield)", 121, MPI_Wtime()-t0 )
     endif
 
 
@@ -182,7 +182,7 @@ subroutine coarseningIndicator_tree( time, params, level_this, hvy_block, hvy_tm
         ! during dev is it useful to know what the normalization is, if that is active
         call append_t_file('eps_norm.t', (/time, norm, params%eps/))
 
-        call toc( "coarseningIndicator (norm)", MPI_Wtime()-t0 )
+        call toc( "coarseningIndicator (norm)", 122, MPI_Wtime()-t0 )
     endif
 
     !---------------------------------------------------------------------------
@@ -275,7 +275,7 @@ subroutine coarseningIndicator_tree( time, params, level_this, hvy_block, hvy_tm
                 endif
             endif
         enddo
-        call toc( "coarseningIndicator (coarseIndicator_block)", MPI_Wtime()-t0 )
+        call toc( "coarseningIndicator (coarseIndicator_block)", 123, MPI_Wtime()-t0 )
 
     end select
 
@@ -289,7 +289,7 @@ subroutine coarseningIndicator_tree( time, params, level_this, hvy_block, hvy_tm
         ! in that case we set the neighbouring block to be important as well (with a temporary flag)
         t0 = MPI_Wtime()
         call addSecurityZone_CE_tree( time, params, tree_ID, hvy_block, hvy_tmp, indicator, norm, inputIsWD)
-        call toc( "coarseningIndicator (security_zone_check)", MPI_Wtime()-t0)
+        call toc( "coarseningIndicator (security_zone_check)", 124, MPI_Wtime()-t0)
     endif
 
 end subroutine

--- a/LIB/MESH/createMask_tree.f90
+++ b/LIB/MESH/createMask_tree.f90
@@ -209,7 +209,7 @@ subroutine createTimeIndependentMask_tree(params, time, hvy_mask, hvy_tmp)
         ! Note: at this point he grid is rather coarse (fewer blocks), and the sync step is rather cheap.
         ! Snyc'ing becomes much more expensive once the grid is refined.
         ! sync possible only before pruning
-        call sync_ghosts_all( params, lgt_block, hvy_mask, hvy_neighbor, hvy_active(:,tree_ID_mask), hvy_n(tree_ID_mask) )
+        call sync_ghosts_tree( params, hvy_mask, tree_ID_mask )
 
 
         ! refine the mesh
@@ -256,7 +256,7 @@ subroutine createTimeIndependentMask_tree(params, time, hvy_mask, hvy_tmp)
 
     ! syncing now and pruning later keeps the ghost nodes of the time-independent mask function sync'ed (as they
     ! do not change)
-    call sync_ghosts_all( params, lgt_block, hvy_mask, hvy_neighbor, hvy_active(:,tree_ID_mask), hvy_n(tree_ID_mask) )
+    call sync_ghosts_tree( params, hvy_mask, tree_ID_mask )
 
     ! we need the mask function both on Jmax (during the RHS) and Jmax-1
     ! (during saving after coarsening)

--- a/LIB/MESH/create_active_and_sorted_lists.f90
+++ b/LIB/MESH/create_active_and_sorted_lists.f90
@@ -116,12 +116,12 @@
 !         call quicksort(lgt_sortednumlist(:,:,tree_ID), 1, lgt_n(tree_ID), 2)
 !     end if
 !     t(5) = MPI_wtime()
-!     call toc("createActiveSortedLists_tree (reset lgt_n)", t(1)-t0)
-!     call toc("createActiveSortedLists_tree (loop over hvy_n)", t(2)-t(1))
-!     call toc("createActiveSortedLists_tree (comm)", t(3)-t(2))
-!     call toc("createActiveSortedLists_tree (loop over lgt_n_sum)", t(4)-t(3))
-!     call toc("createActiveSortedLists_tree (quicksort)", t(5)-t(4))
-!     call toc("createActiveSortedLists_tree", MPI_wtime()-t0)
+    ! call toc("createActiveSortedLists_tree (reset lgt_n)", 51, t(1)-t0)
+    ! call toc("createActiveSortedLists_tree (loop over hvy_n)", 52, t(2)-t(1))
+    ! call toc("createActiveSortedLists_tree (comm)", 53, t(3)-t(2))
+    ! call toc("createActiveSortedLists_tree (loop over lgt_n)", 54, t(4)-t(3))
+    ! call toc("createActiveSortedLists_tree (quicksort)", 55, t(5)-t(4))
+    ! call toc("createActiveSortedLists_tree (TOTAL)", 50, MPI_wtime()-t0)
 ! end subroutine createActiveSortedLists_tree_comm
 
 
@@ -260,12 +260,12 @@ subroutine createActiveSortedLists_tree( params, tree_ID)
         call quicksort(lgt_sortednumlist(:,:,tree_ID), 1, lgt_n(tree_ID), 4)
     end if
     t(5) = MPI_wtime()
-    call toc("createActiveSortedLists_tree (reset lgt_n)", t(1)-t0)
-    call toc("createActiveSortedLists_tree (loop over hvy_n)", t(2)-t(1))
-    call toc("createActiveSortedLists_tree (comm)", t(3)-t(2))
-    call toc("createActiveSortedLists_tree (loop over lgt_n)", t(4)-t(3))
-    call toc("createActiveSortedLists_tree (quicksort)", t(5)-t(4))
-    call toc("createActiveSortedLists_tree", MPI_wtime()-t0)
+    call toc("createActiveSortedLists_tree (reset lgt_n)", 51, t(1)-t0)
+    call toc("createActiveSortedLists_tree (loop over hvy_n)", 52, t(2)-t(1))
+    call toc("createActiveSortedLists_tree (comm)", 53, t(3)-t(2))
+    call toc("createActiveSortedLists_tree (loop over lgt_n)", 54, t(4)-t(3))
+    call toc("createActiveSortedLists_tree (quicksort)", 55, t(5)-t(4))
+    call toc("createActiveSortedLists_tree (TOTAL)", 50, MPI_wtime()-t0)
 end subroutine createActiveSortedLists_tree
 
 ! ! ################################################################################
@@ -360,11 +360,11 @@ end subroutine createActiveSortedLists_tree
 !         call quicksort(lgt_sortednumlist(:,:,tree_ID), 1, lgt_n(tree_ID), 2)
 !     end if
 !     t(4) = MPI_wtime()
-!     call toc("createActiveSortedLists_tree (set lgt_n)", t(1)-t0)
-!     call toc("createActiveSortedLists_tree (reset lgt,hvy list)", t(2)-t(1))
-!     call toc("createActiveSortedLists_tree (loop over lgt_n)", t(3)-t(2))
-!     call toc("createActiveSortedLists_tree (quicksort)", t(4)-t(3))
-!     call toc("createActiveSortedLists_tree", MPI_wtime()-t0)
+!     call toc("createActiveSortedLists_tree (set lgt_n)", 51, t(1)-t0)
+!     call toc("createActiveSortedLists_tree (reset lgt,hvy list)", 52, t(2)-t(1))
+!     call toc("createActiveSortedLists_tree (loop over lgt_n)", 53, t(3)-t(2))
+!     call toc("createActiveSortedLists_tree (quicksort)", 54, t(4)-t(3))
+!     call toc("createActiveSortedLists_tree (total)", 50, MPI_wtime()-t0)
 ! end subroutine createActiveSortedLists_tree_old
 
 
@@ -528,7 +528,7 @@ end subroutine createActiveSortedLists_tree
 !     ! The forest size is defined as the maximum number of trees in the forest.
 !     if (tree_n > fsize) call abort(1402192, "Too many trees in the forest!!" )
 
-!     call toc("createActiveSortedLists_forest", MPI_wtime()-t0)
+!     call toc("createActiveSortedLists_forest", 58, MPI_wtime()-t0)
 ! end subroutine createActiveSortedLists_forest_comm
 
 
@@ -662,5 +662,5 @@ subroutine createActiveSortedLists_forest(params)
     ! The forest size is defined as the maximum number of trees in the forest.
     if (tree_n > fsize) call abort(1402192, "Too many trees in the forest!!" )
 
-    call toc("createActiveSortedLists_forest", MPI_wtime()-t0)
+    call toc("createActiveSortedLists_forest", 58, MPI_wtime()-t0)
 end subroutine createActiveSortedLists_forest

--- a/LIB/MESH/ensureGradedness_tree.f90
+++ b/LIB/MESH/ensureGradedness_tree.f90
@@ -193,7 +193,7 @@ subroutine ensureGradedness_tree( params, tree_ID, mark_TMP_flag )
                 end do
             end if ! refinement status
         end do ! loop over blocks
-        call toc( "ensureGradedness_tree (processing part)", MPI_Wtime()-t0 )
+        call toc( "ensureGradedness_tree (processing part)", 130, MPI_Wtime()-t0 )
 
         ! since not all mpiranks change something in their light data, but all have to perform
         ! the same iterations, we sync the grid_changed indicator here. Note each mpirank changed
@@ -204,7 +204,7 @@ subroutine ensureGradedness_tree( params, tree_ID, mark_TMP_flag )
         !> after locally modifying refinement statusses, we need to synchronize light data
         t0 = MPI_wtime()
         call synchronize_lgt_data( params, refinement_status_only=.true. )
-        call toc( "ensureGradedness_tree (sync_lgt)", MPI_Wtime()-t0 )
+        call toc( "ensureGradedness_tree (sync_lgt)", 131, MPI_Wtime()-t0 )
 
         ! avoid infinite loops
         counter = counter + 1

--- a/LIB/MESH/ensure_completeness.f90
+++ b/LIB/MESH/ensure_completeness.f90
@@ -4,18 +4,24 @@
 ! ********************************************************************************************
 !> \image html completeness.svg "Ensure Completeness" width=400
 
-subroutine ensure_completeness( params, lgt_id, sisters )
+subroutine ensure_completeness( params, lgt_id, sisters, mark_TMP_flag )
 
     implicit none
 
-    type (type_params), intent(in)      :: params                         !> user defined parameter structure
-    integer(kind=ik), intent(inout)     :: sisters(:)    !> light data array
-    integer(kind=ik), intent(in)        :: lgt_id
-    integer(kind=ik)                    :: Jmax                           ! max treelevel
-    integer(kind=ik)                    :: k, l, N_sisters, status        ! loop variables
+    type (type_params), intent(in)      :: params                         !< user defined parameter structure
+    integer(kind=ik), intent(inout)     :: sisters(:)                     !< light data array
+    integer(kind=ik), intent(in)        :: lgt_id                         !< Concerned Block
+    logical, intent(in), optional       :: mark_TMP_flag                  !< Set refinement of completeness to 0 or temporary flag
+    integer(kind=ik)                    :: Jmax, k, l                     ! max treelevel
+    integer(kind=ik)                    :: N_sisters, status, markTMPflag ! loop variables
 
     Jmax = params%Jmax
     N_sisters = size(sisters)
+
+    markTMPflag = 0
+    if (present(mark_TMP_flag)) then
+        if (mark_TMP_flag) markTMPflag = REF_TMP_TREATED_COARSEN
+    endif
 
     ! if all sisters exists, then the array should not contain values smaller
     ! zero (-1 would mean not found)
@@ -33,21 +39,23 @@ subroutine ensure_completeness( params, lgt_id, sisters )
             do l = 1, N_sisters
                 lgt_block( sisters(l), IDX_REFINE_STS )  = -1
             end do
-        else
+        elseif ( status >= 0 ) then
             ! We found all sister blocks, but they do not all share the -1 status: none
             ! of them can be coarsened, remove the status.
             do l = 1, N_sisters
                 lgt_block( sisters(l), IDX_REFINE_STS )  = 0
             end do
+        else
+            call abort(197005, "This is odd - all sisters have temporary flag?")
         end if
     else
         ! We did not even find all sisters, that means a part of the four blocks is already
         ! refined. Therefore, they cannot be coarsened in any case, and we remove the coarsen
         ! flag
         do l = 1, N_sisters
-            ! change status only for the existing sisters
+            ! change status only for the existing sisters, mark temporary for leaf-wise as maybe this sister will be created soon
             if (sisters(l)>0) then
-                lgt_block( sisters(l), IDX_REFINE_STS )  = 0
+                lgt_block( sisters(l), IDX_REFINE_STS )  = markTMPflag
             endif
         end do
     end if

--- a/LIB/MESH/ensure_completeness.f90
+++ b/LIB/MESH/ensure_completeness.f90
@@ -41,12 +41,13 @@ subroutine ensure_completeness( params, lgt_id, sisters, mark_TMP_flag )
             end do
         elseif ( status >= 0 ) then
             ! We found all sister blocks, but they do not all share the -1 status: none
-            ! of them can be coarsened, remove the status.
+            ! of them can be coarsened, remove the coarsening status by passing it on
+            ! can be 0 for staying or REF_TMP_GRADED_STAY which will be simply passed on
             do l = 1, N_sisters
-                lgt_block( sisters(l), IDX_REFINE_STS )  = 0
+                lgt_block( sisters(l), IDX_REFINE_STS )  = status
             end do
         else
-            call abort(197005, "This is odd - all sisters have temporary flag?")
+            call abort(197005, "This is odd - all sisters have temporary flag <-1?")
         end if
     else
         ! We did not even find all sisters, that means a part of the four blocks is already
@@ -54,7 +55,7 @@ subroutine ensure_completeness( params, lgt_id, sisters, mark_TMP_flag )
         ! flag
         do l = 1, N_sisters
             ! change status only for the existing sisters, mark temporary for leaf-wise as maybe this sister will be created soon
-            if (sisters(l)>0) then
+            if (sisters(l) /= -1) then
                 lgt_block( sisters(l), IDX_REFINE_STS )  = markTMPflag
             endif
         end do

--- a/LIB/MESH/executeCoarsening_tree.f90
+++ b/LIB/MESH/executeCoarsening_tree.f90
@@ -287,15 +287,15 @@ subroutine executeCoarsening_WD_tree( params, hvy_block, tree_ID, mark_TMP_flag 
 
 
     ! actual xfer, this works on all blocks that have a mother / daughter
-    call prepare_update_family_metadata(params, lgt_block, hvy_family, hvy_active(:, tree_ID), hvy_n(tree_ID), n_xfer, size(hvy_block, 4), &
+    call prepare_update_family_metadata(params, tree_ID, n_xfer, size(hvy_block, 4), &
         s_M2C=.true.)
-    call xfer_block_data(params, hvy_block, n_xfer, verbose_check=.true.)
+    call xfer_block_data(params, hvy_block, tree_ID, n_xfer)
 
     ! now the mother refinement flags have to be reset and daughter blocks to be deleted
     do k = 1, lgt_n(tree_ID)
         lgtID = lgt_active(k, tree_ID)
         level_me = lgt_block( lgtID, IDX_MESH_LVL )
-        ! delete daughter blocks
+        ! delete daughter blocks that wanted to refine
         if ( lgt_block(lgtID, IDX_REFINE_STS) == -1) then
             lgt_block(lgtID, :) = -1
             lgt_block(lgtID, IDX_REFINE_STS) = 0

--- a/LIB/MESH/executeCoarsening_tree.f90
+++ b/LIB/MESH/executeCoarsening_tree.f90
@@ -200,7 +200,9 @@ subroutine executeCoarsening_WD_tree( params, hvy_block, tree_ID, mark_TMP_flag 
     ! setup correct patches and get indices, used for move_mallat_patch_block
     ! this is in theory only needed when we change g but if this is every done I want to avoid nasty bug finding
     call family_setup_patches(params, output_to_file=.false.)
-
+    ! some tiny buffers depend on the number of components (nc=size(hvy_block,4))
+    ! make sure they have the right size
+    call xfer_ensure_correct_buffer_size(params, hvy_block)
 
     !---------------------------------------------------------------------------
     ! create new empty blocks on rank with most daughters if it does not exist

--- a/LIB/MESH/find_neighbors.f90
+++ b/LIB/MESH/find_neighbors.f90
@@ -612,12 +612,12 @@ subroutine find_neighbor(params, hvyID_block, lgtID_block, Jmax, dir, error, n_d
                 end if
 
                 ! we did not find a neighbor. that may be a bad grid error, or simply, there is none
-                ! because symmetry conditions are used.
-                if (thereMustBeANeighbor) then
-                    if ((.not. exists .and. ALL(params%periodic_BC)).or.(maxval(abs(n_domain))==0.and..not.exists)) then
-                        ! construct print format dynamically after Jmax
-                        write(*, '("Dir ", i0, ", lvl_down=", l1, " lvl=", i0, ":", 4(1x, i0), " TC: ", b64.64)') &
-                            dir, lvl_down_neighbor, level+1, tcFinerAppendDigit, tcb_Block
+                ! because symmetry conditions are used, check for .not. error to only print it once
+                if (thereMustBeANeighbor .and. .not. error) then
+                    if (.not. exists .and. ( ALL(params%periodic_BC) .or. maxval(abs(n_domain))==0)) then
+                        call adjacent_wrapper_b(tcb_Block, tcb_Virtual, dir, level=level, dim=params%dim, max_level=Jmax)
+                        write(*, '("Rank: ", i0, ", found no neighbor in direction: ", i0, ", lgtID-", i0, " lvl-", i0, " TC-", i0, "-", b64.64, A, "Checked same-lvl TC-", i0, "-", b64.64, " and lower-lvl TC-", i0, "-", b64.64)') &
+                            params%rank, dir, lgtID_block, level, tcb_Block, tcb_Block, NEW_LINE('a'), tcb_Virtual, tcb_Virtual, tcb_Neighbor, tcb_Neighbor
                         error = .true.
                     endif
                 endif

--- a/LIB/MESH/forest.f90
+++ b/LIB/MESH/forest.f90
@@ -460,7 +460,7 @@ subroutine copy_tree(params, hvy_block, tree_ID_dest, tree_ID_source)
 
     call updateMetadata_tree( params, tree_ID_dest )
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID_dest), hvy_n(tree_ID_dest))
+    call sync_ghosts_tree( params, hvy_block, tree_ID_dest)
 
     call toc( "copy_tree (copy synchronize hvy and lgt)", 251, MPI_Wtime()-t_elapse )
 
@@ -644,7 +644,7 @@ subroutine coarse_tree_2_reference_mesh(params, lgt_block_ref, lgt_active_ref, l
         endif
     end do
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+    call sync_ghosts_tree( params, hvy_block, tree_ID)
     call balanceLoad_tree( params, hvy_block, tree_ID )
 end subroutine
 
@@ -815,12 +815,12 @@ subroutine refine_trees2same_lvl(params, hvy_block, hvy_tmp, tree_ID1, tree_ID2,
             ! update neighbor relations and synchronice ghosts of 1st tree
             call updateNeighbors_tree( params, tree_ID1 )
 
-            call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID1), hvy_n(tree_ID1))
+            call sync_ghosts_tree( params, hvy_block, tree_ID1)
 
             ! update neighbor relations and synchronice ghosts of 2nd tree
             call updateNeighbors_tree( params, tree_ID2 )
 
-            call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID2), hvy_n(tree_ID2))
+            call sync_ghosts_tree( params, hvy_block, tree_ID2)
 
         endif
     end do
@@ -865,7 +865,7 @@ subroutine refine_tree2(params, hvy_block, hvy_tmp, tree_ID)
     call updateMetadata_tree(params, tree_ID)
 
     ! synchronize ghosts
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID), hvy_n(tree_ID))
+    call sync_ghosts_tree( params, hvy_block, tree_ID)
 end subroutine
 !##############################################################
 
@@ -1449,7 +1449,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
 
         call updateMetadata_tree( params, tree_ID1 )
 
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID1), hvy_n(tree_ID1))
+        call sync_ghosts_tree( params, hvy_block, tree_ID1)
     endif
 
     params%wavelet = MR
@@ -1465,7 +1465,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
     !     ! update neighbor relations and synchronice ghosts of 1st tree
     !     call updateNeighbors_tree( params, lgt_block, hvy_neighbor, lgt_active(:, dest_tree_ID), &
     !     lgt_n(dest_tree_ID), lgt_sortednumlist(:,:,dest_tree_ID), hvy_active(:, dest_tree_ID), hvy_n(dest_tree_ID) )
-    !     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, dest_tree_ID), hvy_n(dest_tree_ID))
+    !     call sync_ghosts_tree( params, hvy_block, dest_tree_ID)
     !     if (tree_ID1 .ne. tree_ID2) then
     !         call coarse_tree_2_reference_mesh(params, tree_n, &
     !             lgt_block, lgt_active(:,tree_ID1),lgt_n, lgt_sortednumlist(:,:,tree_ID1), &
@@ -1481,7 +1481,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
     !     ! update neighbor relations and synchronice ghosts of 1st tree
     !     call updateNeighbors_tree( params, lgt_block, hvy_neighbor, lgt_active(:, tree_ID1), &
     !     lgt_n(tree_ID1), lgt_sortednumlist(:,:,tree_ID1), hvy_active(:, tree_ID1), hvy_n(tree_ID1) )
-    !     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID1), hvy_n(tree_ID1))
+    !     call sync_ghosts_tree( params, hvy_block, tree_ID1)
     !
     !     call adapt_tree( 0.0_rk, params, lgt_block, hvy_block, hvy_neighbor, lgt_active(:,tree_ID2), &
     !     lgt_n(tree_ID2), lgt_sortednumlist(:,:,tree_ID2), hvy_active(:,tree_ID2), &

--- a/LIB/MESH/forest.f90
+++ b/LIB/MESH/forest.f90
@@ -450,7 +450,7 @@ subroutine copy_tree(params, hvy_block, tree_ID_dest, tree_ID_source)
         !--------------------
         hvy_block( :, :, :, :, hvy_id_dest) = hvy_block( :, :, :, :, hvy_id_source)
     end do ! loop over source tree
-    call toc( "copy_tree (copy heavy_data)", MPI_Wtime()-t_elapse )
+    call toc( "copy_tree (copy heavy_data)", 250, MPI_Wtime()-t_elapse )
 
 
     ! always synchronize lgt_data when you have changed lgt_block locally
@@ -462,7 +462,7 @@ subroutine copy_tree(params, hvy_block, tree_ID_dest, tree_ID_source)
 
     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID_dest), hvy_n(tree_ID_dest))
 
-    call toc( "copy_tree (copy synchronize hvy and lgt)", MPI_Wtime()-t_elapse )
+    call toc( "copy_tree (copy synchronize hvy and lgt)", 251, MPI_Wtime()-t_elapse )
 
 end subroutine
 !##############################################################
@@ -964,7 +964,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
         call store_ref_meshes(lgt_block_ref, lgt_active_ref, lgt_n_ref, tree_ID1, tree_ID2)
 
         call refine_trees2same_lvl(params, hvy_block, hvy_tmp, tree_ID1, tree_ID2)
-        call toc( "pointwise_tree_arithmetic (refine_trees2same_lvl)", MPI_Wtime()-t_elapse )
+        call toc( "pointwise_tree_arithmetic (refine_trees2same_lvl)", 252, MPI_Wtime()-t_elapse )
     end if
 
     if (tree_ID1 .ne. tree_ID2) then
@@ -977,7 +977,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
         call balanceLoad_tree( params, hvy_block, tree_ID2 )
     end if
 
-    call toc( "pointwise_tree_arithmetic (balancing after refine_trees2same_lvl)", MPI_Wtime()-t_elapse )
+    call toc( "pointwise_tree_arithmetic (balancing after refine_trees2same_lvl)", 253, MPI_Wtime()-t_elapse )
 
     !=================================================
     ! Decide which pointwice arithmetic shell be used
@@ -1423,7 +1423,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
     case default
         call abort(135,"Operation:  "//op//"  unknown")
     end select
-    call toc( "pointwise_tree_arithmetic (hvy_data operation)", MPI_Wtime()-t_elapse )
+    call toc( "pointwise_tree_arithmetic (hvy_data operation)", 254, MPI_Wtime()-t_elapse )
 
     t_elapse = MPI_Wtime()
 
@@ -1487,7 +1487,7 @@ subroutine tree_pointwise_arithmetic(params, hvy_block, hvy_tmp, tree_ID1, tree_
     !     lgt_n(tree_ID2), lgt_sortednumlist(:,:,tree_ID2), hvy_active(:,tree_ID2), &
     !     hvy_n(tree_ID2), tree_ID2, params%coarsening_indicator, hvy_tmp )
     ! end if
-    call toc( "pointwise_tree_arithmetic (coarse to reference mesh)", MPI_Wtime()-t_elapse )
+    call toc( "pointwise_tree_arithmetic (coarse to reference mesh)", 255, MPI_Wtime()-t_elapse )
 end subroutine
 !##############################################################
 
@@ -1820,9 +1820,9 @@ function scalar_product_two_trees( params, hvy_block, hvy_tmp ,&
 
     t_elapse = MPI_WTIME() - t_elapse
 
-    call toc( "scalra prod (prepare: refine_tree+balanceLoad_tree)", t_inc(1) )
-    call toc( "scalra prod (hvy_data operation)", t_inc(2) )
-    call toc( "scalra prod (total)", t_elapse )
+    call toc( "scalra prod (prepare: refine_tree+balanceLoad_tree)", 256, t_inc(1) )
+    call toc( "scalra prod (hvy_data operation)", 257, t_inc(2) )
+    call toc( "scalra prod (total)", 258, t_elapse )
 end function
 !##############################################################
 

--- a/LIB/MESH/module_mesh.f90
+++ b/LIB/MESH/module_mesh.f90
@@ -25,6 +25,10 @@ module module_mesh
         module procedure set_desired_num_blocks_per_rank1, set_desired_num_blocks_per_rank2
     end interface
 
+    ! used in adapt_tree to work leaf-wise
+    integer, parameter :: REF_TMP_UNTREATED = -2             ! should be < -1
+    integer, parameter :: REF_TMP_TREATED_COARSEN = -3       ! should be < -1
+
 
 contains
 
@@ -33,7 +37,6 @@ contains
 #include "unitTest_ghostSync.f90"
 #include "unitTest_waveletDecomposition.f90"
 #include "unitTest_refineCoarsen.f90"
-#include "waveletDecomposition_tree.f90"
 #include "refineToEquidistant_tree.f90"
 #include "InputOutput_Flusi.f90"
 #include "InputOutput.f90"

--- a/LIB/MESH/refineToEquidistant_tree.f90
+++ b/LIB/MESH/refineToEquidistant_tree.f90
@@ -92,7 +92,7 @@ subroutine refineToEquidistant_tree(params, hvy_block, hvy_tmp, tree_ID, target_
 
         call updateMetadata_tree(params, tree_ID)
 
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, tree_ID), hvy_n(tree_ID) )
+        call sync_ghosts_tree( params, hvy_block, tree_ID )
     end do
 
     ! final balancing: this routine is often used in postprocessing (and during simulations

--- a/LIB/MESH/refine_tree.f90
+++ b/LIB/MESH/refine_tree.f90
@@ -42,14 +42,14 @@ subroutine refine_tree( params, hvy_block, hvy_tmp, indicator, tree_ID  )
     !> (a) loop over the blocks and set their refinement status.
     t1 = MPI_Wtime()
     call refinementIndicator_tree( params, hvy_block, tree_ID, indicator )
-    call toc( "refine_tree (refinementIndicator_tree)", MPI_Wtime()-t1 )
+    call toc( "refine_tree (refinementIndicator_tree)", 141, MPI_Wtime()-t1 )
 
 
     !> (b) remove refinement flag for blocks that are on the finest level and thus
     !! cannot be refined anymore.
     t1 = MPI_Wtime()
     call respectJmaxJmin_tree( params, tree_ID )
-    call toc( "refine_tree (respectJmaxJmin_tree)", MPI_Wtime()-t1 )
+    call toc( "refine_tree (respectJmaxJmin_tree)", 142, MPI_Wtime()-t1 )
 
 
     !> (c) ensure gradedness of mesh. If the refinement is done everywhere, there is
@@ -59,7 +59,7 @@ subroutine refine_tree( params, hvy_block, hvy_tmp, indicator, tree_ID  )
     if ( indicator /= "everywhere" ) then
       call ensureGradedness_tree( params, tree_ID )
     endif
-    call toc( "refine_tree (ensureGradedness_tree)", MPI_Wtime()-t1 )
+    call toc( "refine_tree (ensureGradedness_tree)", 143, MPI_Wtime()-t1 )
 
 
     !---------------------------------------------------------------------------
@@ -101,7 +101,7 @@ subroutine refine_tree( params, hvy_block, hvy_tmp, indicator, tree_ID  )
     else
         call refinementExecute2D_tree( params, hvy_block(:,:,1,:,:), tree_ID )
     end if
-    call toc( "refine_tree (refinement_execute)", MPI_Wtime()-t1 )
+    call toc( "refine_tree (refinement_execute)", 144, MPI_Wtime()-t1 )
 
 
     !> (e) as the grid changed now with the refinement, we have to update the list of
@@ -124,13 +124,13 @@ subroutine refine_tree( params, hvy_block, hvy_tmp, indicator, tree_ID  )
     if ((params%force_maxlevel_dealiasing .eqv. .false.) .or. (indicator/="everywhere")) then
         t1 = MPI_Wtime()
         call balanceLoad_tree( params, hvy_block, tree_ID )
-        call toc( "refine_tree (balanceLoad_tree)", MPI_Wtime()-t1 )
+        call toc( "refine_tree (balanceLoad_tree)", 145, MPI_Wtime()-t1 )
     endif
 
     ! call coarseExtensionUpdate_tree( params, lgt_block, hvy_block, hvy_tmp, hvy_neighbor, &
     ! hvy_active(:,tree_ID), hvy_n(tree_ID), inputDataSynced=.false. )
 
-    call toc( "refine_tree (lists+neighbors)", t_misc )
-    call toc( "refine_tree (TOTAL)", MPI_wtime()-t0 )
+    call toc( "refine_tree (lists+neighbors)", 146, t_misc )
+    call toc( "refine_tree (TOTAL)", 140, MPI_wtime()-t0 )
 
 end subroutine refine_tree

--- a/LIB/MESH/respectJmaxJmin_tree.f90
+++ b/LIB/MESH/respectJmaxJmin_tree.f90
@@ -1,10 +1,10 @@
 subroutine respectJmaxJmin_tree( params, tree_ID)
     implicit none
 
-    type (type_params), intent(in)      :: params           !> user defined parameter structure
-    integer(kind=ik), intent(in)        :: tree_ID
-    integer(kind=ik)                    :: Jmax, Jmin       ! treelevel restrictions
-    integer(kind=ik)                    :: k , lgt_id               ! loop variables
+    type (type_params), intent(in)      :: params                       !< User defined parameter structure
+    integer(kind=ik), intent(in)        :: tree_ID                      !< Tree we look at
+    integer(kind=ik)                    :: Jmax, Jmin                   !< Treelevel restrictions
+    integer(kind=ik)                    :: k, lgt_id, ref_stat, level  !< Loop variables
 
     Jmax = params%Jmax
     Jmin = params%Jmin
@@ -14,14 +14,17 @@ subroutine respectJmaxJmin_tree( params, tree_ID)
 
         lgt_id = lgt_active(k, tree_ID)
 
-        if ((lgt_block( lgt_id, IDX_REFINE_STS ) == +1_ik).and.(lgt_block( lgt_id, IDX_MESH_LVL ) >= Jmax)) then
+        ref_stat = lgt_block( lgt_id, IDX_REFINE_STS )
+        level = lgt_block( lgt_id, IDX_MESH_LVL )
+
+        if ((ref_stat == +1).and.(level >= Jmax)) then
             ! can not refine (set flag to 0 = stay)
-            lgt_block( lgt_id, IDX_REFINE_STS ) = 0_ik
+            lgt_block( lgt_id, IDX_REFINE_STS ) = 0
         end if
 
-        if ((lgt_block( lgt_id, IDX_REFINE_STS ) == -1_ik).and.(lgt_block( lgt_id, IDX_MESH_LVL ) <= Jmin)) then
-            ! can not coarsen
-            lgt_block( lgt_id, IDX_REFINE_STS ) = 0_ik
+        if ((ref_stat == -1 .or. ref_stat == REF_TMP_TREATED_COARSEN).and.(level <= Jmin)) then
+            ! can not coarsen (set flag to 0 = stay)
+            lgt_block( lgt_id, IDX_REFINE_STS ) = 0
         end if
 
     end do

--- a/LIB/MESH/unitTest_ghostSync.f90
+++ b/LIB/MESH/unitTest_ghostSync.f90
@@ -162,7 +162,7 @@ subroutine unitTest_ghostSync( params, hvy_block, hvy_work, hvy_tmp, tree_ID, ab
         !-----------------------------------------------------------------------
         ! synchronize ghost nodes (this is what we test here)
         !-----------------------------------------------------------------------
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+        call sync_ghosts_tree( params, hvy_block, tree_ID )
 
         !-----------------------------------------------------------------------
         ! compute error (normalized, global, 2-norm)

--- a/LIB/MESH/unitTest_refineCoarsen.f90
+++ b/LIB/MESH/unitTest_refineCoarsen.f90
@@ -69,16 +69,14 @@ subroutine unitTest_refineCoarsen( params, hvy_block, hvy_work, hvy_tmp, tree_ID
         endif
     end do
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, &
-    hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     call componentWiseNorm_tree(params, hvy_block, tree_ID, "L2", norm_ref)
 
     ! refine
     call refine_tree( params, hvy_block, hvy_tmp, "everywhere", tree_ID  )
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, &
-    hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     ! coarsening (back to the original level)
     call adapt_tree( 0.0_rk, params, hvy_block, tree_ID, "everywhere", hvy_tmp)

--- a/LIB/MESH/unitTest_waveletDecomposition.f90
+++ b/LIB/MESH/unitTest_waveletDecomposition.f90
@@ -60,8 +60,7 @@ subroutine unitTest_waveletDecomposition( params, hvy_block, hvy_work, hvy_tmp, 
         endif
     end do
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, &
-    hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     call componentWiseNorm_tree(params, hvy_block, tree_ID, "L2", norm_ref)
 
@@ -74,8 +73,7 @@ subroutine unitTest_waveletDecomposition( params, hvy_block, hvy_work, hvy_tmp, 
         call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
     end do
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, &
-    hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
 
     !---------------------------------------------------------------------------

--- a/LIB/MESH/updateMetadata_tree.f90
+++ b/LIB/MESH/updateMetadata_tree.f90
@@ -9,14 +9,16 @@
 ! NOTE: we require the light data lgt_block to be synchronized BEFORE calling this routine.
 !       No synchronization step is required afterwards.
 !
-subroutine updateMetadata_tree(params, tree_ID, update_neighbors, update_family)
+subroutine updateMetadata_tree(params, tree_ID, update_neighbors, update_family, verbose_check)
     implicit none
 
     type (type_params), intent(in) :: params            !< good ol' params
     integer(kind=ik), intent(in)   :: tree_ID           !< Tree to look at
     logical, optional, intent(in)  :: update_neighbors  !< flag if neighbours should be updated, defaults to .true.
     logical, optional, intent(in)  :: update_family     !< flag if family should be updated, defaults to .true.
+    logical, optional, intent(in)  :: verbose_check  ! Output verbose flag
 
+    integer(kind=ik) :: k_b, lgt_ID
     real(kind=rk) :: t0
     logical u_n, u_f
     t0 = MPI_wtime()
@@ -28,6 +30,23 @@ subroutine updateMetadata_tree(params, tree_ID, update_neighbors, update_family)
 
     call createActiveSortedLists_tree(params, tree_ID)
     ! call createActiveSortedLists_tree_old(params, tree_ID)
+
+    ! if (present(verbose_check) .and. params%rank == 0) then
+    !     if (params%rank == 0) then
+    !         do k_b = 1, lgt_n(tree_ID)
+    !             lgt_ID = lgt_active(k_b, tree_ID)
+    !             write(*, '("2 - R0 - Exists BL-", i0, " L-", i0, " Ref-", i0, " TC-", i0, " - ", b32.32)') lgt_ID, &
+    !                 lgt_block(lgt_id, IDX_MESH_LVL), lgt_block(lgt_id, IDX_REFINE_STS), lgt_block(lgt_id, IDX_TC_2), lgt_block(lgt_id, IDX_TC_2)
+    !         enddo
+    !         do k_b = 1, lgt_n(tree_ID)
+    !             lgt_ID = lgt_sortednumlist(1, k_b, tree_ID)
+    !             write(*, '("3 - R0 - Exists BL-", i0, " L-", i0, " Ref-", i0, " TC-List-", i0, " - ", b32.32, " TC-", i0, " - ", b32.32)') lgt_ID, &
+    !                 lgt_block(lgt_id, IDX_MESH_LVL), lgt_block(lgt_id, IDX_REFINE_STS), &
+    !                 lgt_sortednumlist(3, k_b, tree_ID), lgt_sortednumlist(3, k_b, tree_ID), &
+    !                 lgt_block(lgt_id, IDX_TC_2), lgt_block(lgt_id, IDX_TC_2)
+    !         enddo
+    !     endif
+    ! endif
 
     if (u_n) call updateNeighbors_tree(params, tree_ID)
     if (u_f) call updateFamily_tree(params, tree_ID)

--- a/LIB/MESH/updateMetadata_tree.f90
+++ b/LIB/MESH/updateMetadata_tree.f90
@@ -32,5 +32,5 @@ subroutine updateMetadata_tree(params, tree_ID, update_neighbors, update_family)
     if (u_n) call updateNeighbors_tree(params, tree_ID)
     if (u_f) call updateFamily_tree(params, tree_ID)
 
-    call toc( "updateMetadata_tree (lists+neighbors)", MPI_wtime()-t0 )
+    call toc( "updateMetadata_tree (lists+neighbors)", 59, MPI_wtime()-t0 )
 end subroutine

--- a/LIB/MPI/calc_data_bounds.f90
+++ b/LIB/MPI/calc_data_bounds.f90
@@ -1642,7 +1642,7 @@ subroutine set_recv_bounds( params, data_bounds, relation, level_diff, gminus, g
             data_bounds(1,2) = g+1
             data_bounds(2,2) = Bs(2)+g
             data_bounds(1,3) = g+1
-            data_bounds(2,3) = Bs(2)+g
+            data_bounds(2,3) = Bs(3)+g
         !---3D------family relation, assume values on finer side are already WD in mallat-ordering
         case(-1, -2, -3, -4, -5, -6, -7, -8)
             if (level_diff == 0) then
@@ -1655,7 +1655,7 @@ subroutine set_recv_bounds( params, data_bounds, relation, level_diff, gminus, g
                 data_bounds(1,2) = ceiling(g/2.0)+1
                 data_bounds(2,2) = ceiling(g/2.0)+Bs(2)/2
                 data_bounds(1,3) = ceiling(g/2.0)+1
-                data_bounds(2,3) = ceiling(g/2.0)+Bs(2)/2
+                data_bounds(2,3) = ceiling(g/2.0)+Bs(3)/2
             ! Transfer directly into domain wich is not decomposed so we only select the part
             else
                 if (modulo(-relation-1, 2) == 0) then
@@ -1674,7 +1674,7 @@ subroutine set_recv_bounds( params, data_bounds, relation, level_diff, gminus, g
                 endif
                 if (modulo((-relation-1)/4, 2) == 0) then
                     data_bounds(1,3) = g+1
-                    data_bounds(2,3) = g+Bs(2)/2
+                    data_bounds(2,3) = g+Bs(3)/2
                 else
                     data_bounds(1,3) = g+1+Bs(3)/2
                     data_bounds(2,3) = g+Bs(3)

--- a/LIB/MPI/module_mpi.f90
+++ b/LIB/MPI/module_mpi.f90
@@ -7,6 +7,13 @@ module module_MPI
     use module_treelib
     use module_helpers
 
+    ! NOTE: after 24/08/2022, the arrays lgt_active/lgt_n hvy_active/hvy_n as well as lgt_sortednumlist,
+    ! hvy_neighbors, tree_N and lgt_block are global variables included via the module_forestMetaData. This is not
+    ! the ideal solution, as it is trickier to see what does in/out of a routine. But it drastically shortenes
+    ! the subroutine calls, and it is easier to include new variables (without having to pass them through from main
+    ! to the last subroutine.)  -Thomas
+    use module_forestMetaData
+
     implicit none
 
     ! I usually find it helpful to use the private keyword by itself initially, which specifies
@@ -63,9 +70,11 @@ module module_MPI
     logical :: ghost_nodes_module_ready = .false.
 
     ! As we always loop over hvy_id, only one block needs to be filtered at a time, so if we filter a new block we scrap the old filtered values
-    real(kind=rk), allocatable :: hvy_filtered(:, :, :, :)
+    real(kind=rk), allocatable :: hvy_restricted(:, :, :, :)
+    real(kind=rk), allocatable :: hvy_predicted(:, :, :, :)
     ! We need to save which block currently is filtered
-    integer(kind=ik) :: filtered_hvy_ID
+    integer(kind=ik) :: restricted_hvy_ID
+    integer(kind=ik) :: predicted_hvy_ID
 
 
 
@@ -77,9 +86,9 @@ module module_MPI
 !---------------------------------------------------------------------------------------------
 ! public parts of this module
 
-    PUBLIC :: sync_ghosts_all, sync_level_with_all_neighbours, sync_level_to_all_neighbours, sync_level_only, sync_TMP_from_MF, sync_SCWC_from_MC
+    PUBLIC :: sync_ghosts_tree, sync_TMP_from_MF, sync_TMP_from_all, sync_SCWC_from_MC
     PUBLIC :: blocks_per_mpirank, synchronize_lgt_data, reset_ghost_nodes, init_ghost_nodes, move_mallat_patch_block, family_setup_patches, xfer_ensure_correct_buffer_size
-    PUBLIC :: coarseExtensionUpdate_level, coarse_extension_modify_tree, coarse_extension_reconstruct_tree, xfer_block_data, prepare_update_family_metadata
+    PUBLIC :: coarse_extension_modify_tree, coarse_extension_reconstruct_tree, xfer_block_data, prepare_update_family_metadata
 
     ! we set up a table that gives us directly the inverse neighbor relations.
     ! it is filled (once) in init_ghost_nodes
@@ -408,12 +417,21 @@ subroutine xfer_ensure_correct_buffer_size(params, hvy_block)
     endif
 
     ! initialize that no block is currently filtered
-    filtered_hvy_ID = -1
+    restricted_hvy_ID = -1
+    predicted_hvy_ID = -1
 
-    if (allocated(hvy_filtered)) then
-        if (nc > size(hvy_filtered, 4)) deallocate(hvy_filtered)
+    if (allocated(hvy_restricted)) then
+        if (nc > size(hvy_restricted, 4)) deallocate(hvy_restricted)
     endif
-    if (.not. allocated(hvy_filtered)) allocate(hvy_filtered(1:nx, 1:ny, 1:nz, 1:nc) )
+    if (.not. allocated(hvy_restricted)) allocate(hvy_restricted(1:nx, 1:ny, 1:nz, 1:nc) )
+
+    if (allocated(hvy_predicted)) then
+        if (nc > size(hvy_predicted, 4)) deallocate(hvy_predicted)
+    endif
+    if (.not. allocated(hvy_restricted)) then
+        if (params%dim == 3) allocate(hvy_restricted(1:nx*2, 1:ny*2, 1:nz*2, 1:nc) )
+        if (params%dim == 2) allocate(hvy_restricted(1:nx*2, 1:ny*2, 1, 1:nc) )
+    endif
 
 
 end subroutine

--- a/LIB/MPI/module_mpi.f90
+++ b/LIB/MPI/module_mpi.f90
@@ -19,7 +19,7 @@ module module_MPI
     ! send/receive buffer, integer and real
     ! allocate in init substep not in synchronize subroutine, to avoid slow down when using
     ! large numbers of processes and blocks per process, when allocating on every call to the routine
-    integer(kind=ik), PARAMETER   :: S_META_FULL = 6  ! how many metadata entries we collect in the logik-loop
+    integer(kind=ik), PARAMETER   :: S_META_FULL = 7  ! how many metadata entries we collect in the logik-loop
 #ifdef DEV
     integer(kind=ik), PARAMETER   :: S_META_SEND = 5  ! how many metadata entries will be send, plus rank
 #else
@@ -62,13 +62,10 @@ module module_MPI
     ! we use this flag to call the allocation routine only once.
     logical :: ghost_nodes_module_ready = .false.
 
-    ! FIXME: This is a very large work array - equivalent of a whole statevector copy.
-    ! only a subset of it will be actually used, still.
-    ! Its tedious to pass another work array (and hvy_tmp is not the right size neither)
-    ! So for now this is a HACK solution
-    real(kind=rk), allocatable :: hvy_filtered(:, :, :, :, :)
-    ! the 2nd one is small:
-    logical, allocatable :: isFiltered(:)
+    ! As we always loop over hvy_id, only one block needs to be filtered at a time, so if we filter a new block we scrap the old filtered values
+    real(kind=rk), allocatable :: hvy_filtered(:, :, :, :)
+    ! We need to save which block currently is filtered
+    integer(kind=ik) :: filtered_hvy_ID
 
 
 
@@ -80,9 +77,9 @@ module module_MPI
 !---------------------------------------------------------------------------------------------
 ! public parts of this module
 
-    PUBLIC :: sync_ghosts_all, sync_level_with_all_neighbours, sync_level_to_all_neighbours, sync_level_only, sync_level_from_MC
+    PUBLIC :: sync_ghosts_all, sync_level_with_all_neighbours, sync_level_to_all_neighbours, sync_level_only, sync_TMP_from_MF, sync_SCWC_from_MC
     PUBLIC :: blocks_per_mpirank, synchronize_lgt_data, reset_ghost_nodes, init_ghost_nodes, move_mallat_patch_block, family_setup_patches
-    PUBLIC :: coarseExtensionUpdate_level, coarse_extension_modify_level, coarse_extension_reconstruct_level, xfer_block_data, prepare_update_family_metadata
+    PUBLIC :: coarseExtensionUpdate_level, coarse_extension_modify_tree, coarse_extension_reconstruct_tree, xfer_block_data, prepare_update_family_metadata
 
     ! we set up a table that gives us directly the inverse neighbor relations.
     ! it is filled (once) in init_ghost_nodes
@@ -410,19 +407,13 @@ subroutine ghosts_ensure_correct_buffer_size(params, hvy_block)
         allocate( tmp_block( Bs(1)+2*g, Bs(2)+2*g, 1, nc) )
     endif
 
-    if (allocated(isFiltered)) then
-        if (size(isFiltered,1)<size(hvy_block,5)) deallocate(isFiltered)
-    endif
-    if (.not. allocated(isFiltered)) allocate(isFiltered(1:size(hvy_block,5)))
-    ! this one needs initializing:
-    isFiltered = .false.
+    ! initialize that no block is currently filtered
+    filtered_hvy_ID = -1
 
     if (allocated(hvy_filtered)) then
-        if (.not. areArraysSameSize(hvy_block, hvy_filtered)) deallocate(hvy_filtered)
+        if (nc > size(hvy_filtered, 4)) deallocate(hvy_filtered)
     endif
-    ! FIXME: This is a very large work array - equivalent of a whole statevector copy.
-    ! only a subset of it will be actually used, still
-    if (.not. allocated(hvy_filtered)) allocate(hvy_filtered(1:nx, 1:ny, 1:nz, 1:nc, 1:size(hvy_block,5)) )
+    if (.not. allocated(hvy_filtered)) allocate(hvy_filtered(1:nx, 1:ny, 1:nz, 1:nc) )
 
 
 end subroutine

--- a/LIB/MPI/module_mpi.f90
+++ b/LIB/MPI/module_mpi.f90
@@ -78,7 +78,7 @@ module module_MPI
 ! public parts of this module
 
     PUBLIC :: sync_ghosts_all, sync_level_with_all_neighbours, sync_level_to_all_neighbours, sync_level_only, sync_TMP_from_MF, sync_SCWC_from_MC
-    PUBLIC :: blocks_per_mpirank, synchronize_lgt_data, reset_ghost_nodes, init_ghost_nodes, move_mallat_patch_block, family_setup_patches
+    PUBLIC :: blocks_per_mpirank, synchronize_lgt_data, reset_ghost_nodes, init_ghost_nodes, move_mallat_patch_block, family_setup_patches, xfer_ensure_correct_buffer_size
     PUBLIC :: coarseExtensionUpdate_level, coarse_extension_modify_tree, coarse_extension_reconstruct_tree, xfer_block_data, prepare_update_family_metadata
 
     ! we set up a table that gives us directly the inverse neighbor relations.
@@ -377,7 +377,7 @@ subroutine init_ghost_nodes( params )
 
 end subroutine
 
-subroutine ghosts_ensure_correct_buffer_size(params, hvy_block)
+subroutine xfer_ensure_correct_buffer_size(params, hvy_block)
     implicit none
     type (type_params), intent(in) :: params
     real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)

--- a/LIB/MPI/reconstruction_step.f90
+++ b/LIB/MPI/reconstruction_step.f90
@@ -128,7 +128,7 @@ subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, 
             endif
         enddo
     end do
-    call toc( "coarseExtension 1 (toBeManipulated list)", MPI_Wtime()-t0 )
+    call toc( "coarseExtension 1 (toBeManipulated list)", 1010, MPI_Wtime()-t0 )
     ! write(*,*) "rank", params%rank, "N", nnn, hvy_n, lgt_n, "level=", level
     !---------------------------------------------------------------------------
 
@@ -141,7 +141,7 @@ subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, 
         g_this = max(ubound(params%HD,1), ubound(params%GD,1))! ubound GD is the largest (GD is not symmetric but HD is)
         call sync_level_with_all_neighbours( params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, &
             level, g_minus=g_this, g_plus=g_this)
-        call toc( "coarseExtension (sync 1)", MPI_Wtime()-t0 )
+        call toc( "coarseExtension (sync 1)", 1011, MPI_Wtime()-t0 )
     endif
 
 
@@ -176,7 +176,7 @@ subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, 
             call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
         endif
     end do
-    call toc( "coarseExtension 2 (FWT)", MPI_Wtime()-t0 )
+    call toc( "coarseExtension 2 (FWT)", 1012, MPI_Wtime()-t0 )
 
 
     ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -189,7 +189,7 @@ subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, 
     call sync_level_only( params, lgt_block, hvy_block, hvy_neighbor, &
     hvy_active, hvy_n, level, g_minus=g_spaghetti, g_plus=g_spaghetti)
     ! Note we tested it and syncSameLevelOnly1=.true. is indeed slightly faster (compared to full sync)
-    call toc( "coarseExtension 3 (sync 2)", MPI_Wtime()-t0 )
+    call toc( "coarseExtension 3 (sync 2)", 1013, MPI_Wtime()-t0 )
 
 
     ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -314,7 +314,7 @@ subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, 
             endif
         enddo
     end do
-    call toc( "coarseExtension 4 (manipulation loop)", MPI_Wtime()-t0 )
+    call toc( "coarseExtension 4 (manipulation loop)", 1014, MPI_Wtime()-t0 )
 
     ! unfortunately, the above loop affects the load balancing. in the sync_ghosts
     ! step, CPUS will be in sync again, but since they arrive at different times at this line of
@@ -326,7 +326,7 @@ subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, 
     t0 = MPI_Wtime()
     g_this = max(ubound(params%HD,1),ubound(params%GD,1))
     call sync_level_with_all_neighbours( params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, level, g_minus=g_this, g_plus=g_this)
-    call toc( "coarseExtension 5 (sync 3)", MPI_Wtime()-t0 )
+    call toc( "coarseExtension 5 (sync 3)", 1015, MPI_Wtime()-t0 )
 
 
     ! code used to verify that FWT after manip yields same coeffs

--- a/LIB/MPI/reconstruction_step.f90
+++ b/LIB/MPI/reconstruction_step.f90
@@ -1,386 +1,15 @@
-subroutine coarseExtensionUpdate_level( params, lgt_block, hvy_block, hvy_work, hvy_neighbor, hvy_active, hvy_n, lgt_n, &
-    inputDataSynced, level)
-    ! it is not technically required to include the module here, but for VS code it reduces the number of wrong "errors"
-    use module_params
-
-    implicit none
-
-    type (type_params), intent(in)      :: params
-    !> light data array
-    integer(kind=ik), intent(inout)     :: lgt_block(:, :)
-    !> heavy data array - block data
-    real(kind=rk), intent(inout)        :: hvy_block(:, :, :, :, :)
-    real(kind=rk), intent(inout)        :: hvy_work(:, :, :, :, :)
-    !> heavy data array - neighbor data
-    integer(kind=ik), intent(in)        :: hvy_neighbor(:,:)
-    !> list of active blocks (heavy data)
-    integer(kind=ik), intent(in)        :: hvy_active(:)
-    !> number of active blocks (heavy data)
-    integer(kind=ik), intent(in)        :: hvy_n, lgt_n
-    ! if the input data are sync'ed we do not do it here: otherwise, call
-    ! ghost nodes synchronization
-    logical, intent(in) :: inputDataSynced
-    integer(kind=ik), intent(in) :: level
-
-! real(kind=rk), allocatable :: WCtmp(:,:,:,:,:,:) ! code used to verify that FWT after manip yields same coeffs
-    integer(kind=ik) :: N, k, neighborhood, level_diff, hvyID, lgtID, hvyID_neighbor, lgtID_neighbor, level_me, level_neighbor
-    integer(kind=ik) :: nx,ny,nz,nc, g, Bs(1:3), ii, Nreconl, Nreconr, nnn, p, ierr, g_this, g_spaghetti, Nwcl,Nwcr, idx(2,3)
-!    integer(kind=ik) :: ix,iy,iz,ic,iwc ! code used to verify that FWT after manip yields same coeffs
-
-    ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-    ! Note: the precise naming of SC/WC is not really important. we just apply
-    ! the correct decomposition/reconstruction filters - thats it.
-    !
-    ! INDEX            2D     3D     LABEL
-    ! -----            --    ---     ---------------------------------
-    ! wc(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
-    ! wc(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
-    ! wc(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
-    ! wc(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
-    ! wc(:,:,:,:,5)          HHG     wcz wavelet coeffs
-    ! wc(:,:,:,:,6)          HGG     wcxz wavelet coeffs
-    ! wc(:,:,:,:,7)          GHG     wcyz wavelet coeffs
-    ! wc(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
-    !
-    real(kind=rk), allocatable, dimension(:,:,:,:,:), save :: wc
-    real(kind=rk), allocatable, dimension(:,:,:,:), save :: tmp_reconst
-    real(kind=rk) :: t0
-    logical, allocatable, save :: toBeManipulated(:)
-    character(len=80) :: fname
-
-    if (.not. params%isLiftedWavelet) return
-
-    t0 = MPI_Wtime()
-    nx = size(hvy_block, 1)
-    ny = size(hvy_block, 2)
-    nz = size(hvy_block, 3)
-    nc = size(hvy_block, 4)
-    g  = params%g
-    Bs = params%bs
-    Nreconl = params%Nreconl
-    Nreconr = params%Nreconr 
-
-    if ((Bs(1) < Nreconr-g).or.(Bs(2) < Nreconr-g)) then
-        ! NOTE: Nreconr > Nreconl always.
-        write(*,*) params%wavelet, "Bs=", Bs, "Bs_min=", Nreconr-g
-        call abort(991234, "For the chosen wavelet, block size is too small!")
-    endif
-
-    ! it turns out, when the coefficients are spaghetti-ordered,
-    ! we can sync one less point and still have enough coefficients.
-    select case(params%wavelet)
-    case("CDF44")
-        g_spaghetti = 6
-    case("CDF42")
-        g_spaghetti = 4
-    case("CDF22")
-        g_spaghetti = 2
-    case default
-        ! full sync of all points
-        g_spaghetti = g
-    end select
-
-    ! HUGE ! code used to verify that FWT after manip yields same coeffs
-    ! allocate(WCtmp(1:nx, 1:ny, 1:nz, 1:nc, 1:8, 1:size(hvy_block,5))) ! code used to verify that FWT after manip yields same coeffs
-
-    if (allocated(tmp_reconst)) then
-        if (.not. areArraysSameSize(hvy_block(:,:,:,:,1), tmp_reconst) ) deallocate(tmp_reconst)
-    endif
-    if (allocated(wc)) then
-        if (.not. areArraysSameSize(hvy_block(:,:,:,:,1), wc(:,:,:,:,1)) ) deallocate(wc)
-    endif
-    if (.not. allocated(wc)) allocate(wc(1:nx, 1:ny, 1:nz, 1:nc, 1:8) )
-    if (.not. allocated(tmp_reconst)) allocate(tmp_reconst(1:nx, 1:ny, 1:nz, 1:nc) )
-
-    !---------------------------------------------------------------------------
-    ! create the list of blocks that will be affected by coarseExtension.
-    ! It is a heavy array (distributed). This avoids checking again and again
-    ! and improves code readability - performance-wise it does not matter
-    if (allocated(toBeManipulated)) then
-        if (size(toBeManipulated,1) < hvy_n) deallocate(toBeManipulated)
-    endif
-    if (.not. allocated(toBeManipulated)) allocate(toBeManipulated(1:hvy_n))
-
-    ! default no block is to be manipulated
-    toBeManipulated(1:hvy_n) = .false.
-
-    ! check for all blocks if they have coarser neighbors - in this case they'll be manipulated
-    ! nnn = 0
-    do k = 1, hvy_n
-        hvyID = hvy_active(k)
-        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
-
-        do neighborhood = 1, size(hvy_neighbor, 2)
-            ! neighbor exists ?
-            if ( hvy_neighbor(hvyID, neighborhood) /= -1 ) then
-                ! neighbor light data id
-                lgtID_neighbor = hvy_neighbor( hvyID, neighborhood )
-                level_me       = lgt_block( lgtID, IDX_MESH_LVL )
-                level_neighbor = lgt_block( lgtID_neighbor, IDX_MESH_LVL )
-
-                ! we proceed level-wise
-                if ((level_neighbor < level_me).and.(level_me==level)) then
-                    toBeManipulated(k) = .true.
-                    ! nnn = nnn + 1
-                    ! its enough if one neighborhood is true
-                    exit
-                endif
-            endif
-        enddo
-    end do
-    call toc( "coarseExtension 1 (toBeManipulated list)", 1010, MPI_Wtime()-t0 )
-    ! write(*,*) "rank", params%rank, "N", nnn, hvy_n, lgt_n, "level=", level
-    !---------------------------------------------------------------------------
-
-
-    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ! 1st, we sync the ghost nodes, in order to apply the decomposition filters
-    ! HD and GD to the data. It may be that this sync'ing is done before calling.
-    if (.not. inputDataSynced) then
-        t0 = MPI_Wtime()
-        g_this = max(ubound(params%HD,1), ubound(params%GD,1))! ubound GD is the largest (GD is not symmetric but HD is)
-        call sync_level_with_all_neighbours( params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, &
-            level, g_minus=g_this, g_plus=g_this)
-        call toc( "coarseExtension (sync 1)", 1011, MPI_Wtime()-t0 )
-    endif
-
-
-    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ! 2nd. We compute the FWT decomposition by applying the HD GD filters to the data on level "level".
-    ! Data are filtered, decimated and then stored in the block in Spaghetti order (the counterpart
-    ! to Mallat ordering). Coefficients SC and WC are computed only inside the block
-    ! not in the ghost nodes (that is trivial: we cannot compute the filters in the ghost node
-    ! layer). The first point (g+1),(g+1) is a scaling function coefficient, regardless of g
-    ! odd or even. Bs must be even. We also make a copy of the sync'ed data n hvy_work - we use this
-    ! to fix up the SC in the coarse extension case. 
-    ! NOTE: we indeed need to tranform more blocks than we'll actually modify with coarseExt. Strictly speaking,
-    ! FWT is required for blocks 
-    ! (1) are affected by coarse Ext
-    ! (2) blocks that are neighbors to blocks from (1)
-    ! because we need to sync their WC. However, this logic is not implemented, and we FWT all blocks on the level.
-    t0 = MPI_Wtime()
-    do k = 1, hvy_n
-        hvyID = hvy_active(k)
-
-        ! We compute detail coefficients on the fly here, for all blocks
-        ! on the level.
-        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
-        level_me = lgt_block( lgtID, IDX_MESH_LVL )
-
-        ! FWT required for a block that is on the level
-        if (level_me == level) then
-            ! hvy_work now is a copy with sync'ed ghost points.
-            hvy_work(:,:,:,1:nc,hvyID) = hvy_block(:,:,:,1:nc,hvyID)
-
-            ! data WC/SC now in Spaghetti order
-            call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
-        endif
-    end do
-    call toc( "coarseExtension 2 (FWT)", 1012, MPI_Wtime()-t0 )
-
-
-    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ! 3rd we sync the WC coefficients, but only on the same level. This is
-    ! required as several fine blocks hit a coarse one, and this means we have to sync
-    ! those in order to be able to reconstruct with modified WC/SC. Note it does not matter
-    ! if all blocks are sync'ed: we'll not reconstruct on the coarse block anyways, and the
-    ! ghost nodes on the fine bloc (WC/SC) are overwritten in the coarse-extension assumption anyways.
-    t0 = MPI_Wtime()
-    call sync_level_only( params, lgt_block, hvy_block, hvy_neighbor, &
-    hvy_active, hvy_n, level, g_minus=g_spaghetti, g_plus=g_spaghetti)
-    ! Note we tested it and syncSameLevelOnly1=.true. is indeed slightly faster (compared to full sync)
-    call toc( "coarseExtension 3 (sync 2)", 1013, MPI_Wtime()-t0 )
-
-
-    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ! 3B) : Not all blocks will be modified by coarseExtension, but are still FWT'ed.
-    ! We restore those blocks now (by copying back the backup and avoiding the expensive IWT).
-    ! As we already have the FWT here, we might as well compute the largest WC (detail for coarseningIndicator)
-    do k = 1, hvy_n
-        hvyID = hvy_active(k)
-
-        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
-        level_me = lgt_block( lgtID, IDX_MESH_LVL )
-        
-        if (.not. toBeManipulated(k) .and. (level_me==level)) then
-            ! this block has been FWT'ed but is not modified, howver, we can extract its details now
-            call spaghetti2inflatedMallat_block(params, hvy_block(:,:,:,:,hvyID), wc)
-
-            ! ! extract largest wavelet coeffcienct
-            ! do p = 1, nc
-            !     if (params%dim==3) then
-            !         hvy_details(p, hvyID) = maxval( abs(wc(g+1:Bs(1)+g, g+1:Bs(2)+g, g+1:Bs(3)+g, p, 2:8)) )
-            !     else
-            !         hvy_details(p, hvyID) = maxval( abs(wc(g+1:Bs(1)+g, g+1:Bs(2)+g, :, p, 2:4)) )
-            !     endif
-            ! enddo
-
-            ! restore original data (this block is not modified, but currently transformed to wavelet space)
-            hvy_block(:,:,:,1:nc,hvyID) = hvy_work(:,:,:,1:nc,hvyID)
-        endif
-    enddo   
-
-
-    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ! 4th. Loop over all blocks and check if they have *coarser* neighbors
-    ! routine operates on a single tree (not a forest)
-    t0 = MPI_Wtime()
-    do k = 1, hvy_n
-        hvyID = hvy_active(k)
-        call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
-
-        ! this block just remains the same as before..
-        if (.not. toBeManipulated(k)) cycle
-        
-        ! ===> the following code is only executed for blocks that are manipulated by CE
-
-        ! copy transformed data to "inflated mallat ordering":
-        call spaghetti2inflatedMallat_block(params, hvy_block(:,:,:,:,hvyID), wc)
-
-        ! loop over all relevant neighbors
-        do neighborhood = 1, size(hvy_neighbor, 2)
-            ! neighbor exists ?
-            if ( hvy_neighbor(hvyID, neighborhood) /= -1 ) then
-                ! neighbor light data id
-                lgtID_neighbor = hvy_neighbor( hvyID, neighborhood )
-                level_me       = lgt_block( lgtID, IDX_MESH_LVL )
-                level_neighbor = lgt_block( lgtID_neighbor, IDX_MESH_LVL )
-
-                if (level_neighbor < level_me) then
-                    ! manipulation of coeffs
-                    call coarseExtensionManipulateWC_block(params, wc, neighborhood)
-                    call coarseExtensionManipulateSC_block(params, wc, hvy_work(:,:,:,:,hvyID), neighborhood)
-                elseif (level_neighbor > level_me) then
-                    ! it is actually possible for a block to have both finer and coarser neighbors. If its
-                    ! coarser, (level_neighbor<level_me), then coarseExtension is applied to this block.
-                    ! However for small Bs (or large wavelets, i.e. large Nreconr Nreconl), the coarseExt
-                    ! reconstruction step also takes into account the ghost nodes layer on the adjacent 
-                    ! side. If this adjacent block is then finer (level_neighbor > level_me), those WC
-                    ! should be zero and this is what we assure here.
-                    call coarseExtensionManipulateWC_block(params, wc, neighborhood, params%g, params%g)
-                    ! note if the neighboring blocks are on the same level, the WC are sync'ed between the 
-                    ! blocks, and we must NOT delete them.
-                    
-                    ! What about the SC?
-                    ! See the extensive comment in WaveDecomposition_dim1 on that. 
-                    ! "Magically", the SC are correct.
-                endif
-            endif
-        enddo
-
-        ! WCtmp(:,:,:,:,1:8,hvyID) = wc ! code used to verify that FWT after manip yields same coeffs
-
-        ! ! evaluate detail for blocks that were affected by coarseExtension (blocks on
-        ! ! the level J which are not affected by it are computed above)
-        ! do p = 1, nc
-        !     if (params%dim==3) then
-        !         hvy_details(p, hvyID) = maxval( abs(wc(g+1:Bs(1)+g, g+1:Bs(2)+g, g+1:Bs(3)+g, p, 2:8)) )
-        !     else
-        !         hvy_details(p, hvyID) = maxval( abs(wc(g+1:Bs(1)+g, g+1:Bs(2)+g, :, p, 2:4)) )
-        !     endif
-        ! enddo
-
-        ! copy back original data, then fix the coarse extension parts by
-        ! copying tmp_reconst (the inverse of the manipulated SC/WC) into the patches
-        ! relevant for coarse extension
-        hvy_block(:,:,:,1:nc,hvyID) = hvy_work(:,:,:,1:nc,hvyID)
-
-        ! reconstruct from the manipulated coefficients
-        call inflatedMallat2spaghetti_block(params, wc, tmp_reconst)
-        call waveletReconstruction_block(params, tmp_reconst)
-
-        ! reconstruction part. We manipulated the data and reconstructed them on the entire block with modified coeffs.
-        ! Now, we copy those reconstructed data back to the original block - this is
-        ! the actual coarseExtension.
-        ! JB: In theory we synched the SC and WC of the same level so we could overwrite the whole domain
-        !     however, as with blocks with both finer and coarser neighbours the finer neighbours do not synch WC and SC
-        !     the WR reconstructs false values at the border there
-        !     For CVS this problem should solve itself as every block can find same-level neighbours for all directions
-        do neighborhood = 1, size(hvy_neighbor,2)
-            if ( hvy_neighbor(hvyID, neighborhood) /= -1 ) then
-                ! neighbor light data id
-                lgtID_neighbor = hvy_neighbor( hvyID, neighborhood )
-                level_me       = lgt_block( lgtID, IDX_MESH_LVL )
-                level_neighbor = lgt_block( lgtID_neighbor, IDX_MESH_LVL )
-
-                if (level_neighbor < level_me) then
-                    ! coarse extension case (neighbor is coarser)
-                    idx(:, :) = 1
-                    call get_indices_of_modify_patch(params, neighborhood, idx, (/ nx, ny, nz/), (/Nreconl, Nreconl, Nreconl/), (/Nreconr, Nreconr, Nreconr/))
-
-                    hvy_block(idx(1,1):idx(2,1), idx(1,2):idx(2,2), idx(1,3):idx(2,3), 1:nc, hvyID) = &
-                        tmp_reconst(idx(1,1):idx(2,1), idx(1,2):idx(2,2), idx(1,3):idx(2,3), 1:nc)
-                endif
-            endif
-        enddo
-    end do
-    call toc( "coarseExtension 4 (manipulation loop)", 1014, MPI_Wtime()-t0 )
-
-    ! unfortunately, the above loop affects the load balancing. in the sync_ghosts
-    ! step, CPUS will be in sync again, but since they arrive at different times at this line of
-    ! code, idling occurs -> bad for performance.
-
-    ! final sync step. The reason is: we have kept some SC and zeroed some WC, and
-    ! reconstructed the signal. The ghost nodes are outdated now: the reconstruction
-    ! step altered the signal.
-    t0 = MPI_Wtime()
-    g_this = max(ubound(params%HD,1),ubound(params%GD,1))
-    call sync_level_with_all_neighbours( params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, level, g_minus=g_this, g_plus=g_this)
-    call toc( "coarseExtension 5 (sync 3)", 1015, MPI_Wtime()-t0 )
-
-
-    ! code used to verify that FWT after manip yields same coeffs
-    ! do k = 1, hvy_n
-    !     if (.not. toBeManipulated(k)) cycle
-    !
-    !     hvyID = hvy_active(k)
-    !     call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
-    !
-    !     hvy_work(:,:,:,1:nc,hvyID) = hvy_block(:,:,:,1:nc,hvyID)
-    !     call waveletDecomposition_block(params, hvy_work(:,:,:,:,hvyID))
-    !
-    !     call spaghetti2inflatedMallat_block(params, hvy_work(:,:,:,:,hvyID), wc)
-    !
-    !     wc = wc - WCtmp(:,:,:,:,1:8,hvyID)
-    !
-    ! write(fname,'(i1,"_",i0.6,".diff")') params%rank, hvyID
-    ! write(*,*) fname
-    !
-    !     open(14, file=fname, status='replace')
-    !     do ix = g+1, Bs(1)+g!nx
-    !     do iy = g+1, Bs(1)+g!ny
-    !     do iz = g+1, Bs(1)+g!nz
-    !     do iwc = 1, 8
-    !         write(14,'(es15.8))') wc(ix,iy,iz,1,iwc)
-    !     enddo
-    !     enddo
-    !     enddo
-    !     enddo
-    !     close(14)
-    !     abort(197)
-    ! enddo
-    !
-    ! deallocate(WCtmp)
-end subroutine
-
-
-
 !> \brief Modify the SC and WC of a wavelet decomposed blocks at fine/coarse interfaces
 !> This routine assumes that the input is already wavelet decomposed in spaghetti form
 !> It will work on all blocks or which have the REF_TMP_UNTREATED flag in refinement status for leaf-wise operation
-subroutine coarse_extension_modify_tree(params, lgt_block, hvy_data, hvy_tmp, hvy_neighbor, hvy_active, hvy_n, lgt_n, tree_ID, sc_skip_ghosts)
+subroutine coarse_extension_modify_tree(params, hvy_data, hvy_tmp, tree_ID, sc_skip_ghosts)
     ! it is not technically required to include the module here, but for VS code it reduces the number of wrong "errors"
     use module_params
 
     implicit none
 
     type (type_params), intent(in)      :: params
-    integer(kind=ik), intent(inout)     :: lgt_block(:, :)             !< light data array
     real(kind=rk), intent(inout)        :: hvy_data(:, :, :, :, :)     !< heavy data array, WDed in Spaghetti form
     real(kind=rk), intent(inout)        :: hvy_tmp(:, :, :, :, :)      !< heavy work data array - block data.
-    integer(kind=ik), intent(in)        :: hvy_neighbor(:,:)           !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)        :: hvy_active(:)               !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)        :: hvy_n, lgt_n                !< number of active blocks (heavy and light data)
     integer(kind=ik), intent(in)        :: tree_ID                     !< Tree to be investigated
     logical, optional, intent(in)       :: sc_skip_ghosts              !< for second CE modify we can skip ghosts points
 
@@ -402,11 +31,11 @@ subroutine coarse_extension_modify_tree(params, lgt_block, hvy_data, hvy_tmp, hv
     endif
     if (.not. allocated(wc)) allocate(wc(1:nx, 1:ny, 1:nz, 1:nc, 1:8) )
 
-    do k = 1, hvy_n
+    do k = 1, hvy_n(tree_ID)
         ! Set toBeManipulated - This is one of those sneaky errors I searched 10hours for - JB
         toBeManipulated = .false.
 
-        hvyID = hvy_active(k)
+        hvyID = hvy_active(k, tree_ID)
         call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
         level_me       = lgt_block( lgtID, IDX_MESH_LVL )
         tree_me        = lgt_block( lgtID, IDX_TREE_ID )
@@ -445,7 +74,7 @@ subroutine coarse_extension_modify_tree(params, lgt_block, hvy_data, hvy_tmp, hv
                     if (level_neighbor < level_me) then
                         ! manipulation of coeffs
                         call coarseExtensionManipulateWC_block(params, wc, neighborhood)
-                        call coarseExtensionManipulateSC_block(params, wc, hvy_tmp(:,:,:,:,hvyID), neighborhood, scSkipGhosts)
+                        call coarseExtensionManipulateSC_block(params, wc(:, :, :, :, 1), hvy_tmp(:,:,:,:,hvyID), neighborhood, scSkipGhosts)
                     elseif (level_neighbor > level_me) then
                         ! it is actually possible for a block to have both finer and coarser neighbors. If its
                         ! coarser, (level_neighbor<level_me), then coarseExtension is applied to this block.
@@ -473,22 +102,20 @@ end subroutine
 
 
 !> \brief Apply CE for all blocks in a tree. This copies back the old values and then overwrites those on affected patches
-subroutine coarse_extension_reconstruct_tree(params, lgt_block, hvy_data, hvy_tmp, hvy_neighbor, hvy_active, hvy_n, lgt_n)
+subroutine coarse_extension_reconstruct_tree(params, hvy_data, hvy_tmp, tree_ID, REF_TMP_CHECK)
     ! it is not technically required to include the module here, but for VS code it reduces the number of wrong "errors"
     use module_params
 
     implicit none
 
     type (type_params), intent(in)      :: params
-    integer(kind=ik), intent(inout)     :: lgt_block(:, :)             !< light data array
     real(kind=rk), intent(inout)        :: hvy_data(:, :, :, :, :)     !< heavy data array
     real(kind=rk), intent(inout)        :: hvy_tmp(:, :, :, :, :)      !< heavy work data array - block data.
-    integer(kind=ik), intent(in)        :: hvy_neighbor(:,:)           !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)        :: hvy_active(:)               !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)        :: hvy_n, lgt_n                !< number of active blocks (heavy and light data)
+    integer(kind=ik), intent(in)        :: tree_ID                     !< which tree to study
+    integer(kind=ik), intent(in), optional :: REF_TMP_CHECK               !< if this is passed, only blocks with this ref status will be affected at all
 
     integer(kind=ik)                    :: iteration, k, neighborhood, lgtID, hvyID, Nreconl, Nreconr
-    integer(kind=ik)                    :: nx,ny,nz,nc, level_me, level_neighbor, lgtID_neighbor, idx(2,3)
+    integer(kind=ik)                    :: nx,ny,nz,nc, level_me, level_neighbor, lgtID_neighbor, idx(2,3), ref_me
     logical                             :: toBeManipulated
     real(kind=rk), allocatable, dimension(:,:,:,:), save :: tmp_reconst
 
@@ -507,13 +134,20 @@ subroutine coarse_extension_reconstruct_tree(params, lgt_block, hvy_data, hvy_tm
     endif
     if (.not. allocated(tmp_reconst)) allocate(tmp_reconst(1:nx, 1:ny, 1:nz, 1:nc) )
 
-    do k = 1, hvy_n
+    do k = 1, hvy_n(tree_ID)
         ! Set toBeManipulated - This is one of those sneaky errors I searched 10hours for - JB
         toBeManipulated = .false.
 
-        hvyID = hvy_active(k)
+        hvyID = hvy_active(k, tree_ID)
         call hvy2lgt( lgtID, hvyID, params%rank, params%number_blocks )
         level_me       = lgt_block( lgtID, IDX_MESH_LVL )
+
+        ! in some cases not all blocks were wavelet decomposed
+        ! we want to retransform / copy them only if they have the passed refinement status, used for CE_update_tree
+        if (present(REF_TMP_CHECK)) then
+            ref_me = lgt_block( lgtID, IDX_REFINE_STS )
+            if (ref_me /= REF_TMP_CHECK) cycle
+        endif
 
         ! check if this block is to be modified
         do neighborhood = 1, size(hvy_neighbor, 2)
@@ -582,3 +216,4 @@ subroutine coarse_extension_reconstruct_tree(params, lgt_block, hvy_data, hvy_tm
         endif
     enddo
 end subroutine
+

--- a/LIB/MPI/reset_ghost_nodes.f90
+++ b/LIB/MPI/reset_ghost_nodes.f90
@@ -4,31 +4,60 @@
 !! output:   - heavy data array
 ! ********************************************************************************************
 
-subroutine reset_ghost_nodes(  params, hvy_block, hvy_active, hvy_n )
+subroutine reset_ghost_nodes(  params, hvy_block, tree_ID, s_M2M, s_M2C, s_M2F)
     implicit none
 
-    type (type_params), intent(in)      :: params                     !> user defined parameter structure
-    real(kind=rk), intent(inout)        :: hvy_block(:, :, :, :, :)   !> heavy data array - block data
-    integer(kind=ik), intent(in)        :: hvy_active(:)              !> list of active blocks (heavy data)
-    integer(kind=ik), intent(in)        :: hvy_n                      !> number of active blocks (heavy data)
-    integer(kind=ik)                    :: g, hvy_id, k
-    integer(kind=ik), dimension(3)      :: Bs
+    type (type_params), intent(in)      :: params                     !< user defined parameter structure
+    real(kind=rk), intent(inout)        :: hvy_block(:, :, :, :, :)   !< heavy data array - block data
+    integer(kind=ik), intent(in)        :: tree_ID                    !< which tree to study
+    logical, intent(in), optional  :: s_M2M                         !< Synch from level J   to J
+    logical, intent(in), optional  :: s_M2C                         !< Synch from level J   to J-1
+    logical, intent(in), optional  :: s_M2F                         !< Synch from level J   to J+1
+
+    integer(kind=ik)               :: g, hvy_id, k_b, k_n, lgt_id, lgt_id_n, level_me, level_diff
+    integer(kind=ik)               :: Bs(3), ijk(2,3)
+    logical :: SM2M, SM2C, SM2F
+
+    sM2M = .false.
+    sM2C = .false.
+    sM2F = .false.
+    if (present(s_M2M)) sM2M = s_M2M
+    if (present(s_M2C)) sM2C = s_M2C
+    if (present(s_M2F)) sM2F = s_M2F
 
     Bs = params%Bs
     g  = params%g
 
-    do k = 1, hvy_n
-        hvy_ID = hvy_active(k)
-        !-- x-direction
-        hvy_block(1:g, :, :, :, hvy_ID )           = 9.0e9_rk
-        hvy_block(Bs(1)+g+1:Bs(1)+2*g, :, :, :, hvy_ID) = 9.0e9_rk
-        !-- y-direction
-        hvy_block(:, 1:g, :, :, hvy_ID)           = 9.0e9_rk
-        hvy_block(:, Bs(2)+g+1:Bs(2)+2*g, :, :, hvy_ID) = 9.0e9_rk
-        !-- z-direction
-        if ( params%dim == 3 ) then
-          hvy_block(:, :, 1:g, :, hvy_ID)           = 9.0e9_rk
-          hvy_block(:, :, Bs(3)+g+1:Bs(3)+2*g, :, hvy_ID) = 9.0e9_rk
-        end if
+    do k_b = 1, hvy_n(tree_ID)
+        hvy_ID = hvy_active(k_b, tree_ID)
+        call hvy2lgt(lgt_id, hvy_id, params%rank, params%number_blocks)
+        level_me = lgt_block( lgt_id, IDX_MESH_LVL )
+
+        ! loop over all neighborhoods, check if this is synched and then wipe it
+        do k_n = 1, size(hvy_neighbor, 2)
+          lgt_id_n = hvy_neighbor( hvy_id, k_n )
+          if ( lgt_id_n /= -1 ) then
+            level_diff = level_me - lgt_block( lgt_id_n, IDX_MESH_LVL )
+
+            if ((level_diff==0 .and. sM2M) .or. (level_diff==-1 .and. sM2F) .or. (level_diff==+1 .and. sM2C)) then
+              ! get indices of ghost patch that is affected
+              ijk = ijkPatches(:,:, k_n, level_diff, RECVER)
+              ! call get_indices_of_modify_patch(params, k_n, ijk, (/ size(hvy_block, 1), size(hvy_block, 2), size(hvy_block, 3)/), &
+              !   (/params%g, params%g, params%g/), (/params%g, params%g, params%g/))
+              hvy_block(ijk(1,1):ijk(2,1), ijk(1,2):ijk(2,2), ijk(1,3):ijk(2,3), :, hvy_ID )           = 9.0e9_rk
+            endif
+          endif
+        enddo
+        ! !-- x-direction
+        ! hvy_block(1:g, :, :, :, hvy_ID )           = 9.0e9_rk
+        ! hvy_block(Bs(1)+g+1:Bs(1)+2*g, :, :, :, hvy_ID) = 9.0e9_rk
+        ! !-- y-direction
+        ! hvy_block(:, 1:g, :, :, hvy_ID)           = 9.0e9_rk
+        ! hvy_block(:, Bs(2)+g+1:Bs(2)+2*g, :, :, hvy_ID) = 9.0e9_rk
+        ! !-- z-direction
+        ! if ( params%dim == 3 ) then
+        !   hvy_block(:, :, 1:g, :, hvy_ID)           = 9.0e9_rk
+        !   hvy_block(:, :, Bs(3)+g+1:Bs(3)+2*g, :, hvy_ID) = 9.0e9_rk
+        ! end if
     enddo
 end subroutine reset_ghost_nodes

--- a/LIB/MPI/restrict_predict_data.f90
+++ b/LIB/MPI/restrict_predict_data.f90
@@ -17,6 +17,8 @@ subroutine restrict_predict_data( params, res_pre_data, ijk, neighborhood, &
     integer(kind=ik), intent(in)                    :: num_eqn      !< How many components? Needed as in between we use hvy_tmp
     integer(kind=ik), intent(in)                    :: hvy_id
 
+    integer(kind=ik) :: iy  ! debug variable
+
     ! some neighborhoods are intrinsically on the same level (level_diff=0)
     ! and thus it makes no sense to call the up/downsampling routine for those
     if ( params%dim == 3 .and. (neighborhood<=18) ) call abort(323223,"this case shouldnt appear")
@@ -67,11 +69,20 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
     ! by applying the filter only in the required patch.
     ! Pro: we maybe save a bi of CPU time, as we usually do not need the entire block filtered
     ! Con: more work and maybe we compute some values twice (if patches overlap)
-    if (hvy_id /= filtered_hvy_ID) then
-        call blockFilterXYZ_interior_vct( params, hvy_block(:,:,:,1:nc,hvy_id), hvy_filtered(:,:,:,1:nc), params%HD, &
-        lbound(params%HD, dim=1), ubound(params%HD, dim=1), params%g)
+    if (hvy_ID /= restricted_hvy_ID) then
+        call restrict_copy_at_CE(params, hvy_block, hvy_ID, nc)
 
-        filtered_hvy_ID = hvy_id
+        ! call blockFilterXYZ_interior_vct( params, hvy_block(:,:,:,1:nc,hvy_id), hvy_restricted(:,:,:,1:nc), params%HD, &
+        ! lbound(params%HD, dim=1), ubound(params%HD, dim=1), params%g)
+
+        ! if (hvy_id == 17 .and. params%rank == 1) THEN
+        !     write(*, '("Restrict block R-0 BH-7 IJK-", 3(i0, "-"), i0)') ijk(:,1:2)
+        !     do iy = 2,25, 2
+        !         write(*, '(25(es9.2))') hvy_restricted(2:25:2, iy, 1, 1)
+        !     enddo
+        ! endif
+
+        restricted_hvy_ID = hvy_ID
     endif
 
     do dF = 1, nc
@@ -81,7 +92,7 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
 
                     ! write restricted (downsampled) data
                     res_data( (ix-ijk(1,1))/2+1, (iy-ijk(1,2))/2+1, (iz-ijk(1,3))/2+1, dF) &
-                    = hvy_filtered( ix, iy, iz, dF)
+                    = hvy_restricted( ix, iy, iz, dF)
                     ! res_data( (ix-ijk(1,1))/2+1, (iy-ijk(1,2))/2+1, (iz-ijk(1,3))/2+1, dF) &
                     ! = hvy_block( ix, iy, iz, dF, hvy_id )
                 end do
@@ -89,6 +100,57 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
         end do
     end do
 end subroutine restrict_data
+
+
+
+!> \brief Uses HD filter at all interfaces and copies values everywhere where it would use from coarser or finer neighbor
+!> Used for sync in order to match values with coarse extension
+!
+!                      g g g g g g g g         - - - - - - - -
+!                      g g g g g g g g         - - - - - - - -
+!      m c c c         g g i i i i g g         - - i i i i - -
+!      m b b m         g g i i i i g g         - - f f f f - -
+!      m b b m         g g i i i i g g         - - f f f f - -
+!      f m m m         g g i i i i g g         - - i f f f - -
+!                      g g g g g g g g         - - - - - - - -
+!                      g g g g g g g g         - - - - - - - -
+!   Block relations      Block in                Block out
+! b = block, m = medium neighbor, c = coarse n, f = fine n, g = ghost point, i = interior point, f = filtered point, - = value should not be used
+subroutine restrict_copy_at_CE(params, hvy_data, hvy_ID, num_eqn)
+    ! this routine imports forestMetaData as we need to work with hvy_neighbor, hvy_data, lgt_block and others and I want to avoid passing it on everywhere
+    use module_forestMetaData
+
+    implicit none
+    type (type_params), intent(in) :: params  !< good ol params
+    real(kind=rk), intent(inout)   :: hvy_data(:, :, :, :, :)  !< heavy data array - block data
+    integer(kind=ik), intent(in)   :: hvy_id  !< which block to look at
+    integer(kind=ik), intent(in)   :: num_eqn !< How many components? Needed as it could vary
+
+    integer(kind=ik) :: k_n, lvl_me, lvl_diff, lgt_ID, lgt_ID_n, HD_l, HD_r
+
+    HD_l = lbound(params%HD, dim=1)
+    HD_r = ubound(params%HD, dim=1)
+
+    ! filter whole block and don't care about neighbors first
+    call blockFilterXYZ_vct( params, hvy_data(:,:,:,1:num_eqn, hvy_id), hvy_restricted(:,:,:,1:num_eqn), params%HD, HD_l, HD_r)
+
+
+    call hvy2lgt(lgt_ID, hvy_ID, params%rank, params%number_blocks)
+    lvl_me = lgt_block(lgt_ID, IDX_MESH_LVL)
+
+    ! apply copying, do it for fine and coarse neighbors as we assume for coarse n independency and for fine n that they are not synched
+    do k_n = 1, size(hvy_neighbor, 2)
+        ! neighbor exists?
+        lgt_ID_n = hvy_neighbor( hvy_ID, k_n )
+        if ( lgt_ID_n /= -1 ) then
+            lvl_diff = lvl_me - lgt_block(lgt_ID_n, IDX_MESH_LVL)
+            if (lvl_diff == -1 .or. lvl_diff == +1) then
+                call coarseExtensionManipulateSC_block(params, hvy_restricted(:,:,:,1:num_eqn), hvy_data(:,:,:,1:num_eqn, hvy_id), k_n, skip_ghosts=.false.)
+            endif
+        endif
+    end do
+end subroutine
+
 
 
 subroutine predict_data( params, pre_data, ijk, hvy_block, num_eqn, hvy_id )
@@ -106,31 +168,27 @@ subroutine predict_data( params, pre_data, ijk, hvy_block, num_eqn, hvy_id )
 
     integer(kind=ik) :: dF, nx, ny, nz, nc
 
-
-    nc = num_eqn
-
     ! data size
     nx = ijk(2,1) - ijk(1,1) + 1
     ny = ijk(2,2) - ijk(1,2) + 1
     nz = ijk(2,3) - ijk(1,3) + 1
+    nc = num_eqn
 
     ! The neighbor is finer: we have to interpolate the data
-
+    ! Notice how the indices are now in the beginning of the array, this was once decided whysoever (I hope I change it at some point)
     if ( params%dim == 3 ) then
-        ! 3D
+    ! 3D
         do dF = 1, nc
-            call prediction_3D( hvy_block( ijk(1,1):ijk(2,1), ijk(1,2):ijk(2,2), &
-            ijk(1,3):ijk(2,3), dF, hvy_id ), pre_data( 1:2*nx-1, 1:2*ny-1, 1:2*nz-1, dF), &
+            call prediction_3D( hvy_block( ijk(1,1):ijk(2,1), ijk(1,2):ijk(2,2), ijk(1,3):ijk(2,3), dF, hvy_id ), &
+                pre_data( 1:2*nx-1, 1:2*ny-1, 1:2*nz-1, dF), &
             params%order_predictor)
         end do
-
     else
-        ! 2D
+    ! 2D
         do dF = 1, nc
-            call prediction_2D( hvy_block( ijk(1,1):ijk(2,1), ijk(1,2):ijk(2,2),&
-            1, dF, hvy_id ), pre_data( 1:2*nx-1, 1:2*ny-1, 1, dF),  params%order_predictor)
+            call prediction_2D( hvy_block( ijk(1,1):ijk(2,1), ijk(1,2):ijk(2,2), 1, dF, hvy_id ), &
+                pre_data( 1:2*nx-1, 1:2*ny-1, 1, dF),  params%order_predictor)
         end do
-
     end if
 end subroutine predict_data
 

--- a/LIB/MPI/restrict_predict_data.f90
+++ b/LIB/MPI/restrict_predict_data.f90
@@ -68,12 +68,7 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
     ! block. Result is stored in a large work array. Note we could try to optimize this
     ! by applying the filter only in the required patch.
     ! Pro: we maybe save a bi of CPU time, as we usually do not need the entire block filtered
-   - - - - - - - -
-!                      g g g g g g g g         - - - - - - - -
-!   Block relations       Block in                Block out
-! b = block, m = medium neighbor, c = coarse n, f = fine n, g = ghost point, i = interior point, f = filtered point, - = value should not be used
-! Note: The bottom left value is copied (i) due to the finer neighbor in the bottom left corner, the top values due to the coarser top neighbor.
-! Ghost points of output should not be used, as they may have been filtered correctly, partially or left unfiltered arbitrarily    ! Con: more work and maybe we compute some values twice (if patches overlap)
+    ! Con: more work and maybe we compute some values twice (if patches overlap)
     if (hvy_ID /= restricted_hvy_ID) then
         call restrict_copy_at_CE(params, hvy_block, hvy_ID, nc)
 
@@ -112,13 +107,19 @@ end subroutine restrict_data
 !> Used for sync in order to match values with coarse extension. Coarser AND finer neighbors cannot be filtered as there values
 !! are not present in the ghost layers, so for all those patches where filters need those points the values will be copied.
 !
-!                      g g g g g g g g         - - - - - - - -
-!                      g g g g g g g g         - - - - - - - -
+!                      g g o o o o o o         - - - - - - - -
+!                      g g o o o o o o         - - - - - - - -
 !      m c c c         g g i i i i g g         - - i i i i - -
 !      m b b m         g g i i i i g g         - - f f f f - -
 !      m b b m         g g i i i i g g         - - f f f f - -
 !      f m m m         g g i i i i g g         - - i f f f - -
-!                      g g g g g g g g      
+!                      o o g g g g g g         - - - - - - - -
+!                      o o g g g g g g         - - - - - - - -
+!   Block relations       Block in                Block out
+! b = block, m = medium neighbor, c = coarse n, f = fine n
+! g = ghost point, o = outdated ghost point, i = interior point, f = filtered point, - = value should not be used
+! Note: The bottom left value is copied (i) due to the finer neighbor in the bottom left corner, the top values due to the coarser top neighbor.
+! Ghost points of output should not be used, as they may have been filtered correctly, wrongly, partially or left unfiltered arbitrarily
 subroutine restrict_copy_at_CE(params, hvy_data, hvy_ID, num_eqn)
 
     implicit none

--- a/LIB/MPI/synchronize_ghosts_generic.f90
+++ b/LIB/MPI/synchronize_ghosts_generic.f90
@@ -282,7 +282,7 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
         t1 = MPI_wtime()
         call prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_active, hvy_n, count_send_total, &
             istage, ncomponents=size(hvy_block,4), s_Level=sLevel, s_M2M = sM2M, s_M2C = sM2C, s_C2M = sC2M, s_M2F = sM2F, s_F2M = sF2M)
-        call toc( "sync ghosts (prepare metadata)", MPI_wtime()-t1 )
+        call toc( "sync ghosts (prepare metadata)", 81, MPI_wtime()-t1 )
 
         !***************************************************************************
         ! (ii) sending handled by xfer_block_data
@@ -300,11 +300,11 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
                 call xfer_block_data(params, hvy_block, count_send_total, hvy_tmp=hvy_tmp)
             endif
         endif
-        call toc( "sync ghosts (xfer_block_data)", MPI_wtime()-t1 )
+        call toc( "sync ghosts (xfer_block_data)", 82, MPI_wtime()-t1 )
 
     end do ! loop over stages 1,2
 
-    call toc( "WRAPPER: sync ghosts", MPI_wtime()-t0 )
+    call toc( "sync ghosts (TOTAL)", 80, MPI_wtime()-t0 )
 
 end subroutine sync_ghosts_generic
 
@@ -451,7 +451,7 @@ end subroutine sync_ghosts_generic
 !
 !         ! call fixInterpolatedPoints_postSync( params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n)
 !
-!     call toc( "WRAPPER: sync ghosts", MPI_wtime()-t0 )
+!     call toc( "WRAPPER: sync ghosts", 19, MPI_wtime()-t0 )
 !
 ! end subroutine sync_ghosts_nostages
 

--- a/LIB/MPI/synchronize_ghosts_generic.f90
+++ b/LIB/MPI/synchronize_ghosts_generic.f90
@@ -251,7 +251,7 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
     call ghosts_setup_patches(params, gminus=gminus, gplus=gplus, output_to_file=.false.)
     ! some tiny buffers depend on the number of components (nc=size(hvy_block,4))
     ! make sure they have the right size
-    call ghosts_ensure_correct_buffer_size(params, hvy_block)
+    call xfer_ensure_correct_buffer_size(params, hvy_block)
 
 ! Diagonal neighbors (not required for the RHS)
 ! 2D: 5,6,7,8

--- a/LIB/MPI/synchronize_ghosts_generic.f90
+++ b/LIB/MPI/synchronize_ghosts_generic.f90
@@ -1,41 +1,11 @@
-!> Wrapper to synch level only with itself, used for synching wavelet-decomposed values
-subroutine sync_level_only(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, level, g_minus, g_plus)
-    implicit none
-
-    type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
-    real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
-    integer(kind=ik), intent(in) :: level                           !< what level to synch from and to
-    integer(kind=ik), optional, intent(in) :: g_minus, g_plus
-
-    integer(kind=ik) :: gminus, gplus
-    gminus = params%g
-    gplus = params%g
-    ! if we sync a different number of ghost nodes
-    if (present(g_minus)) gminus = g_minus
-    if (present(g_plus))   gplus = g_plus
-
-    ! set level to -1 to enable synching between all
-    call sync_ghosts_generic(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, &
-        g_minus=gminus, g_plus=gplus, s_level=level, s_M2M = .true.)
-
-end subroutine sync_level_only
-
-
 !> Wrapper to synch blocks with temporary flag from finer neighbours and same-level neighbors
 !> Used before wavelet decomposition
-subroutine sync_TMP_from_MF(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, REF_TMP_UNTREATED, hvy_tmp, g_minus, g_plus)
+subroutine sync_TMP_from_MF(params, hvy_block, tree_ID, REF_TMP_UNTREATED, hvy_tmp, g_minus, g_plus)
     implicit none
 
     type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
     real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
+    integer(kind=ik), intent(in)   :: tree_ID                       !< which tree to study
     integer(kind=ik), intent(in)   :: REF_TMP_UNTREATED             !< this block has no access to modul_mesh so we need the flag value
     !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
     real(kind=rk), intent(inout), optional :: hvy_tmp(:, :, :, :, :)
@@ -49,23 +19,47 @@ subroutine sync_TMP_from_MF(params, lgt_block, hvy_block, hvy_neighbor, hvy_acti
     if (present(g_plus))   gplus = g_plus
 
     ! we set s_level to REF_TMP_UNTREATED, this value is < -1 and therefore distinctive, we use this to avoid another parameter
-    call sync_ghosts_generic(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, &
-        g_minus=gminus, g_plus=gplus, s_level=REF_TMP_UNTREATED, s_F2M=.true., s_M2M=.true., hvy_tmp=hvy_tmp)
+    call sync_ghosts_generic(params, hvy_block, tree_ID, g_minus=gminus, g_plus=gplus, s_level=REF_TMP_UNTREATED, s_F2M=.true., s_M2M=.true., s_C2M=.false., hvy_tmp=hvy_tmp)
 
 end subroutine sync_TMP_from_MF
 
 
-!> Wrapper to synch level from coarser neighbours and same-level neighbors
-!! Used after coarse extension to update SC and WC, coarse neighbours need to be synched from hvy_tmp
-subroutine sync_SCWC_from_MC(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, hvy_tmp, g_minus, g_plus)
+
+!> Wrapper to synch blocks with temporary flag from all neighbors
+!> Used before wavelet decomposition
+subroutine sync_TMP_from_all(params, hvy_block, tree_ID, REF_TMP_UNTREATED, hvy_tmp, g_minus, g_plus)
     implicit none
 
     type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
     real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
+    integer(kind=ik), intent(in)   :: tree_ID                       !< which tree to study
+    integer(kind=ik), intent(in)   :: REF_TMP_UNTREATED             !< this block has no access to modul_mesh so we need the flag value
+    !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
+    real(kind=rk), intent(inout), optional :: hvy_tmp(:, :, :, :, :)
+    integer(kind=ik), optional, intent(in) :: g_minus, g_plus         !< Boundary sizes in case we want to send less values
+
+    integer(kind=ik) :: gminus, gplus
+    gminus = params%g
+    gplus = params%g
+    ! if we sync a different number of ghost nodes
+    if (present(g_minus)) gminus = g_minus
+    if (present(g_plus))   gplus = g_plus
+
+    ! we set s_level to REF_TMP_UNTREATED, this value is < -1 and therefore distinctive, we use this to avoid another parameter
+    call sync_ghosts_generic(params, hvy_block, tree_ID, g_minus=gminus, g_plus=gplus, s_level=REF_TMP_UNTREATED, s_F2M=.true., s_M2M=.true., s_C2M=.true., hvy_tmp=hvy_tmp)
+
+end subroutine sync_TMP_from_all
+
+
+
+!> Wrapper to synch level from coarser neighbours and same-level neighbors
+!! Used after coarse extension to update SC and WC, coarse neighbours need to be synched from hvy_tmp
+subroutine sync_SCWC_from_MC(params, hvy_block, tree_ID, hvy_tmp, g_minus, g_plus)
+    implicit none
+
+    type (type_params), intent(in) :: params
+    real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
+    integer(kind=ik), intent(in)   :: tree_ID                       !< which tree to study
     !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
     real(kind=rk), intent(inout)   :: hvy_tmp(:, :, :, :, :)
     integer(kind=ik), optional, intent(in) :: g_minus, g_plus
@@ -78,73 +72,18 @@ subroutine sync_SCWC_from_MC(params, lgt_block, hvy_block, hvy_neighbor, hvy_act
     if (present(g_plus))   gplus = g_plus
 
     ! set level to -1 to enable synching between all
-    call sync_ghosts_generic(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, &
-        g_minus=gminus, g_plus=gplus, s_level=-1, s_M2F=.true., s_M2M=.true., hvy_tmp=hvy_tmp)
+    call sync_ghosts_generic(params, hvy_block, tree_ID, g_minus=gminus, g_plus=gplus, s_level=-1, s_M2F=.true., s_M2M=.true., hvy_tmp=hvy_tmp, verbose_check=.true.)
 
 end subroutine sync_SCWC_from_MC
 
 
-!> Wrapper to synch all ghost-point patches from and between the same level, used for level-wise algorithms
-subroutine sync_level_to_all_neighbours(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, level, g_minus, g_plus)
-    implicit none
-
-    type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
-    real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
-    integer(kind=ik), intent(in) :: level                           !< what level to synch from and to
-    integer(kind=ik), optional, intent(in) :: g_minus, g_plus
-
-    integer(kind=ik) :: gminus, gplus
-    gminus = params%g
-    gplus = params%g
-    ! if we sync a different number of ghost nodes
-    if (present(g_minus)) gminus = g_minus
-    if (present(g_plus))   gplus = g_plus
-
-    call sync_ghosts_generic(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, g_minus=gminus, g_plus=gplus, &
-        s_level=level, s_M2M = .true., s_M2C = .true., s_C2M = .false., s_M2F = .true., s_F2M = .false.)
-
-end subroutine sync_level_to_all_neighbours
-
-
-!> Wrapper to synch all ghost-point patches from and between the same level, used for level-wise algorithms
-subroutine sync_level_with_all_neighbours(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, level, g_minus, g_plus)
-    implicit none
-
-    type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
-    real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
-    integer(kind=ik), intent(in) :: level                           !< what level to synch from and to
-    integer(kind=ik), optional, intent(in) :: g_minus, g_plus
-
-    integer(kind=ik) :: gminus, gplus
-    gminus = params%g
-    gplus = params%g
-    ! if we sync a different number of ghost nodes
-    if (present(g_minus)) gminus = g_minus
-    if (present(g_plus))   gplus = g_plus
-
-    call sync_ghosts_generic(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, g_minus=gminus, g_plus=gplus, &
-        s_level=level, s_M2M = .true., s_M2C = .true., s_C2M = .true., s_M2F = .true., s_F2M = .true.)
-
-end subroutine sync_level_with_all_neighbours
-
 !> Wrapper to synch all ghost-point patches
-subroutine sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, g_minus, g_plus)
+subroutine sync_ghosts_tree(params, hvy_block, tree_ID, g_minus, g_plus)
     implicit none
 
     type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
     real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
+    integer(kind=ik), intent(in)   :: tree_ID                       !< which tree to study
     integer(kind=ik), optional, intent(in) :: g_minus, g_plus
 
     integer(kind=ik) :: gminus, gplus
@@ -155,32 +94,29 @@ subroutine sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_activ
     if (present(g_plus))   gplus = g_plus
 
     ! set level to -1 to enable synching between all, set stati to send to all levels
-    call sync_ghosts_generic(params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, &
-        g_minus=gminus, g_plus=gplus, s_level=-1, s_M2M=.true., s_M2F=.true., s_M2C=.true.)
+    call sync_ghosts_generic(params, hvy_block, tree_ID, g_minus=gminus, g_plus=gplus, s_level=-1, s_M2M=.true., s_M2F=.true., s_M2C=.true.)
 
-end subroutine sync_ghosts_all
+end subroutine sync_ghosts_tree
 
 
 !> This function deals with ghost-node synching \n
 !! It is a generic function with many flags, streamlining all synching process \n
 !! In order to avoid confusion wrapper functions should be used everywhere in order to implement
 !! specific versions. This also means that parameter changes only have to be changed in the wrappers
-subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_active, hvy_n, g_minus, g_plus, &
-    s_level, s_M2M, s_M2C, s_C2M, s_M2F, s_F2M, hvy_tmp)
+subroutine sync_ghosts_generic( params, hvy_block, tree_ID, g_minus, g_plus, &
+    s_level, s_M2M, s_M2C, s_C2M, s_M2F, s_F2M, hvy_tmp, verbose_check)
     ! it is not technically required to include the module here, but for VS code it reduces the number of wrong "errors"
     use module_params
     
     implicit none
 
     type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: lgt_block(:, :)               !< light data array
     real(kind=rk), intent(inout)   :: hvy_block(:, :, :, :, :)      !< heavy data array - block data
-    integer(kind=ik), intent(in)   :: hvy_neighbor(:,:)             !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)   :: hvy_active(:)                 !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)   :: hvy_n                         !< number of active blocks (heavy data)
+    integer(kind=ik), intent(in)   :: tree_ID                       !< which tree to study
 
     !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
     real(kind=rk), intent(inout), optional :: hvy_tmp(:, :, :, :, :)
+    logical, optional, intent(in)  :: verbose_check  ! Output verbose flag
 
     !> Level to synch, if -1 then all levels are synched, if < -1 then it is REF_TMP_UNTREATED and ref status will be checked
     integer(kind=ik), intent(in), optional  :: s_level
@@ -192,7 +128,7 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
     integer(kind=ik), optional, intent(in) :: g_minus, g_plus       !< Synch only so many ghost points
 
     integer(kind=ik) sLevel
-    logical :: SM2M = .false., SM2C = .false., SC2M = .false., SM2F = .false., SF2M = .false.
+    logical :: SM2M, SM2C, SC2M, SM2F, SF2M
 
     integer(kind=ik)   :: myrank, mpisize, Bs(1:3), buffer_offset
     integer(kind=ik)   :: N, k, neighborhood, level_diff, Nstages
@@ -212,9 +148,15 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
     endif
 
     ! if this mpirank has no active blocks, it has nothing to do here.
-    if (hvy_n == 0) return
+    if (hvy_n(tree_ID) == 0) return
 
+    ! initialize variables, to write 5 times .false. might be long but I tried other ways which surprisingly delivered wrong results
     sLevel = -1
+    sM2M = .false.
+    sM2C = .false.
+    sC2M = .false.
+    sM2F = .false.
+    sF2M = .false.
     if (present(s_Level)) sLevel = s_Level
     if (present(s_M2M)) sM2M = s_M2M
     if (present(s_M2C)) sM2C = s_M2C
@@ -228,14 +170,18 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
     N       = params%number_blocks
     myrank  = params%rank
     mpisize = params%number_procs
-    ! default is two stages: first, copy&decimate, then interpolate
-    Nstages = 2
+    ! default is three stages:
+    !    1. M2M, copy
+    !    2. M2C, F2M, decimate, independent from coarser neighbor but needs same-level data
+    !    3. M2F, C2M, interpolate, needs same-level and finer neighbor data
+    Nstages = 3
     ! if we sync a different number of ghost nodes
     if (present(g_minus)) gminus = g_minus
     if (present(g_plus))   gplus = g_plus
 
 #ifdef DEV
-    if (sLevel == -1) call reset_ghost_nodes( params, hvy_block, hvy_active, hvy_n )
+    ! for dev check ghosts by wiping if we set all of them
+    if (sLevel == -1) call reset_ghost_nodes( params, hvy_block, tree_ID, s_M2M=sM2M, s_M2C=sM2C, s_M2F=sM2F)
 #endif
 
     !-----------------------------------------------------------------------
@@ -266,10 +212,6 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
 ! Idea is described in inskape notes.
 !
 
-
-
-
-
     ! We require two stages: first, we fill all ghost nodes which are simple copy (including restriction),
     ! then in the second stage we can use interpolation and fill the remaining ones.
     do istage = 1, Nstages
@@ -280,7 +222,7 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
         ! Also applies logic about what should be synched and saves all metadata unsorted in one array
         ! internal nodes are included in metadata but not counted
         t1 = MPI_wtime()
-        call prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_active, hvy_n, count_send_total, &
+        call prepare_ghost_synch_metadata(params, tree_ID, count_send_total, &
             istage, ncomponents=size(hvy_block,4), s_Level=sLevel, s_M2M = sM2M, s_M2C = sM2C, s_C2M = sC2M, s_M2F = sM2F, s_F2M = sF2M)
         call toc( "sync ghosts (prepare metadata)", 81, MPI_wtime()-t1 )
 
@@ -292,12 +234,12 @@ subroutine sync_ghosts_generic( params, lgt_block, hvy_block, hvy_neighbor, hvy_
         !***************************************************************************
         t1 = MPI_wtime()
         if (.not. present(hvy_tmp)) then
-            call xfer_block_data(params, hvy_block, count_send_total)
+            call xfer_block_data(params, hvy_block, tree_ID, count_send_total, verbose_check=verbose_check)
         else
             if (sLevel < -1) then
-                call xfer_block_data(params, hvy_block, count_send_total, hvy_tmp=hvy_tmp, REF_FLAG=sLevel)
+                call xfer_block_data(params, hvy_block, tree_ID, count_send_total, hvy_tmp=hvy_tmp, REF_FLAG=sLevel, verbose_check=verbose_check)
             else
-                call xfer_block_data(params, hvy_block, count_send_total, hvy_tmp=hvy_tmp)
+                call xfer_block_data(params, hvy_block, tree_ID, count_send_total, hvy_tmp=hvy_tmp, verbose_check=verbose_check)
             endif
         endif
         call toc( "sync ghosts (xfer_block_data)", 82, MPI_wtime()-t1 )
@@ -462,21 +404,18 @@ end subroutine sync_ghosts_generic
 !    - saving of all metadata
 !    - computing of buffer sizes for metadata for both sending and receiving
 ! This is done strictly locally so no MPI needed here
-subroutine prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_active, hvy_n, count_send, istage, ncomponents, &
+subroutine prepare_ghost_synch_metadata(params, tree_ID, count_send, istage, ncomponents, &
     s_Level, s_M2M, s_M2C, s_C2M, s_M2F, s_F2M)
 
     implicit none
 
     type (type_params), intent(in)      :: params
-    integer(kind=ik), intent(in)        :: lgt_block(:, :)     !< light data array
-    integer(kind=ik), intent(in)        :: hvy_neighbor(:,:)   !< heavy data array - neighbor data
-    integer(kind=ik), intent(in)        :: hvy_active(:)       !< list of active blocks (heavy data)
-    integer(kind=ik), intent(in)        :: hvy_n               !< number of active blocks (heavy data)
+    integer(kind=ik), intent(in)        :: tree_ID             !< which tree to study
 
     integer(kind=ik), intent(in)        :: ncomponents         !< components can vary (for mask for example)
     integer(kind=ik), intent(out)       :: count_send          !< number of ghost patches total to be send, for looping
     !> following are variables that control the logic of where each block sends or receives
-    integer(kind=ik), intent(in)        :: istage
+    integer(kind=ik), intent(in)        :: istage  !< current stage out of three
 
     !> Level to synch, if -1 then all levels are synched, if < -1 then it is REF_TMP_UNTREATED and ref status will be checked
     integer(kind=ik), intent(in), optional  :: s_level
@@ -486,7 +425,7 @@ subroutine prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_act
     logical, intent(in), optional  :: s_M2F                         !< Synch from level J   to J+1
     logical, intent(in), optional  :: s_F2M                         !< Synch from level J+1 to J
     integer(kind=ik) sLevel
-    logical :: SM2M = .false., SM2C = .false., SC2M = .false., SM2F = .false., SF2M = .false.
+    logical :: SM2M, SM2C, SC2M, SM2F, SF2M
 
     ! Following are global data used but defined in module_mpi:
     !    data_recv_counter, data_send_counter
@@ -496,7 +435,13 @@ subroutine prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_act
     integer(kind=ik) :: k_block, sender_hvyID, sender_lgtID, sender_ref, myrank, N, neighborhood, recver_rank, recver_ref
     integer(kind=ik) :: ijk(2,3), inverse, ierr, recver_hvyID, recver_lgtID, level, level_diff, status, new_size
 
+    ! initialize variables, to write 5 times .false. might be long but I tried other ways which surprisingly delivered wrong results
     sLevel = -1
+    sM2M = .false.
+    sM2C = .false.
+    sC2M = .false.
+    sM2F = .false.
+    sF2M = .false.
     if (present(s_Level)) sLevel = s_Level
     if (present(s_M2M)) sM2M = s_M2M
     if (present(s_M2C)) sM2C = s_M2C
@@ -516,9 +461,9 @@ subroutine prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_act
     real_pos(:) = 0
 
     count_send = 0
-    do k_block = 1, hvy_n
+    do k_block = 1, hvy_n(tree_ID)
         ! calculate light id
-        sender_hvyID = hvy_active(k_block)
+        sender_hvyID = hvy_active(k_block, tree_ID)
         call hvy2lgt( sender_lgtID, sender_hvyID, myrank, N )
         level = lgt_block( sender_lgtID, IDX_MESH_LVL )
         sender_ref = lgt_block( sender_lgtID, IDX_REFINE_STS)
@@ -550,17 +495,17 @@ subroutine prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_act
                 recver_ref = lgt_block( recver_lgtID, IDX_REFINE_STS)
 
                 ! Send logic, following cases exist currently, all linked as .or.:
-                ! stage=1, level_diff = +1, (sLevel=-1 and M2C) or (level=sLevel and M2C) or (level=sLevel+1 and F2M)
+                ! stage=2, level_diff = +1, (sLevel=-1 and M2C) or (level=sLevel and M2C) or (level=sLevel+1 and F2M)
                 !          or (sLevel<-1 and ref=sLevel and M2C) or (sLevel<-1 and ref_n=sLevel and F2M)
                 ! stage=1, level_diff =  0, (sLevel=-1 and M2M) or (level=sLevel and M2M)
                 !          or (sLevel<-1 and (ref=sLevel  or ref_n=sLevel) and M2M)
-                ! stage=2, level_diff = -1, (sLevel=-1 and M2F) or (level=sLevel and M2F) or (level=sLevel-1 and C2M)
+                ! stage=3, level_diff = -1, (sLevel=-1 and M2F) or (level=sLevel and M2F) or (level=sLevel-1 and C2M)
                 !          or (sLevel<-1 and ref=sLevel and M2F) or (sLevel<-1 and ref_n=sLevel and C2M)
 
                 ! send counter. how much data will I send to other mpiranks?
-                if  ((istage==1 .and. level_diff==+1 .and. ((sLevel==-1 .and. sM2C) .or. (level==sLevel .and. sM2C) .or. (level==sLevel+1 .and. sF2M) &
+                if  ((istage==2 .and. level_diff==+1 .and. ((sLevel==-1 .and. sM2C) .or. (level==sLevel .and. sM2C) .or. (level==sLevel+1 .and. sF2M) &
                     .or. (sLevel<-1 .and. sender_ref==sLevel .and. sM2C) .or. (sLevel<-1 .and. recver_ref==sLevel .and. sF2M))) &
-                .or. (istage==2 .and. level_diff==-1 .and. ((sLevel==-1 .and. sM2F) .or. (level==sLevel .and. sM2F) .or. (level==sLevel-1 .and. sC2M) &
+                .or. (istage==3 .and. level_diff==-1 .and. ((sLevel==-1 .and. sM2F) .or. (level==sLevel .and. sM2F) .or. (level==sLevel-1 .and. sC2M) &
                     .or. (sLevel<-1 .and. sender_ref==sLevel .and. sM2F) .or. (sLevel<-1 .and. recver_ref==sLevel .and. sC2M))) &
                 .or. (istage==1 .and. level_diff== 0 .and. ((sLevel==-1 .and. sM2M) .or. (level==sLevel .and. sM2M) &
                     .or. (sLevel<-1 .and. (sender_ref==sLevel .or. recver_ref==sLevel) .and. sM2M)))) then
@@ -591,19 +536,19 @@ subroutine prepare_ghost_synch_metadata(params, lgt_block, hvy_neighbor, hvy_act
                 endif
 
                 ! Receive logic, following cases exist currently, all linked as .or.:
-                ! stage=1, level_diff = -1, (sLevel=-1 and M2C) or (level=sLevel and F2M) or (level=sLevel-1 and M2C)
+                ! stage=2, level_diff = -1, (sLevel=-1 and M2C) or (level=sLevel and F2M) or (level=sLevel-1 and M2C)
                 !          or (sLevel<-1 and ref_n=sLevel and M2C) or (sLevel<-1 and ref=sLevel and F2M)
                 ! stage=1, level_diff =  0, (sLevel=-1 and M2M) or (level=sLevel and M2M)
                 !          or (sLevel<-1 and (ref=sLevel  or ref_n=sLevel) and M2M)
-                ! stage=2, level_diff = +1, (sLevel=-1 and M2F) or (level=sLevel and C2M) or (level=sLevel+1 and M2F)
+                ! stage=3, level_diff = +1, (sLevel=-1 and M2F) or (level=sLevel and C2M) or (level=sLevel+1 and M2F)
                 !          or (sLevel<-1 and ref_n=sLevel and M2F) or (sLevel<-1 and ref=sLevel and C2M)
 
                 ! recv counter. how much data will I recv from other mpiranks?
                 ! This is NOT the same number as before
                 if (myrank /= recver_rank) then  ! only receive from foreign ranks
-                    if  ((istage==1 .and. level_diff==-1 .and. ((sLevel==-1 .and. sM2C) .or. (level==sLevel .and. sF2M) .or. (level==sLevel-1 .and. sM2C) &
+                    if  ((istage==2 .and. level_diff==-1 .and. ((sLevel==-1 .and. sM2C) .or. (level==sLevel .and. sF2M) .or. (level==sLevel-1 .and. sM2C) &
                         .or. (sLevel<-1 .and. recver_ref==sLevel .and. sM2C) .or. (sLevel<-1 .and. sender_ref==sLevel .and. sF2M))) &
-                    .or. (istage==2 .and. level_diff==+1 .and. ((sLevel==-1 .and. sM2F) .or. (level==sLevel .and. sC2M) .or. (level==sLevel+1 .and. sM2F) &
+                    .or. (istage==3 .and. level_diff==+1 .and. ((sLevel==-1 .and. sM2F) .or. (level==sLevel .and. sC2M) .or. (level==sLevel+1 .and. sM2F) &
                         .or. (sLevel<-1 .and. recver_ref==sLevel .and. sM2F) .or. (sLevel<-1 .and. sender_ref==sLevel .and. sC2M))) &
                     .or. (istage==1 .and. level_diff== 0 .and. ((sLevel==-1 .and. sM2M) .or. (level==sLevel .and. sM2M) &
                         .or. (sLevel<-1 .and. (sender_ref==sLevel .or. recver_ref==sLevel) .and. sM2M)))) then

--- a/LIB/MPI/synchronize_lgt_data.f90
+++ b/LIB/MPI/synchronize_lgt_data.f90
@@ -97,7 +97,7 @@ subroutine synchronize_lgt_data( params, refinement_status_only )
         proc_lgt_start(k) = sum(proc_lgt_num(1:k-1))! + 1
     enddo
 
-    call toc( "synchronize_lgt_data (prep)", MPI_wtime()-t1 )
+    call toc( "synchronize_lgt_data (prep)", 61, MPI_wtime()-t1 )
 
     ! ==========================================================================
     ! The data in lgt_block:
@@ -136,7 +136,7 @@ subroutine synchronize_lgt_data( params, refinement_status_only )
             WABBIT_COMM, ierr)
         enddo
     endif
-    call toc( "synchronize_lgt_data (MPI)", MPI_wtime()-t1 )
+    call toc( "synchronize_lgt_data (MPI)", 62, MPI_wtime()-t1 )
 
     ! we need to delete the old lgt_block array to avoid any rotting corpses somewhere.
     ! it is a little tricky to see why this is the case, but we found it to be necessary.
@@ -166,7 +166,7 @@ subroutine synchronize_lgt_data( params, refinement_status_only )
             end if
         end if
     end do
-    call toc( "synchronize_lgt_data (post)", MPI_wtime()-t1 )
+    call toc( "synchronize_lgt_data (post)", 63, MPI_wtime()-t1 )
 
-    call toc( "synchronize_lgt_data (TOTAL)", MPI_wtime()-t0 )
+    call toc( "synchronize_lgt_data (TOTAL)", 60, MPI_wtime()-t0 )
 end subroutine

--- a/LIB/MPI/xfer_block_data.f90
+++ b/LIB/MPI/xfer_block_data.f90
@@ -52,14 +52,14 @@ subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check, hv
     ! endif
 
     call send_prepare_external(params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG)
-    call toc( "xfer_block_data (prepare data)", MPI_wtime()-t0 )
+    call toc( "xfer_block_data (prepare data)", 70, MPI_wtime()-t0 )
 
     !***************************************************************************
     ! (ii) transfer part (send/recv)
     !***************************************************************************
     t0 = MPI_wtime()
     call start_xfer_mpi( params, isend, irecv, verbose_check)
-    call toc( "xfer_block_data (start_xfer_mpi)", MPI_wtime()-t0 )
+    call toc( "xfer_block_data (start_xfer_mpi)", 71, MPI_wtime()-t0 )
 
     !***************************************************************************
     ! (iii) Unpack received data in the ghost node layers
@@ -67,18 +67,18 @@ subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check, hv
     ! process-internal ghost points (direct copy)
     t0 = MPI_wtime()
     call unpack_ghostlayers_internal( params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG)
-    call toc( "xfer_block_data (unpack internal)", MPI_wtime()-t0 )
+    call toc( "xfer_block_data (unpack internal)", 72, MPI_wtime()-t0 )
 
     ! before unpacking the data we received from other ranks, we wait for the transfer
     ! to be completed
     t0 = MPI_wtime()
     call finalize_xfer_mpi(params, isend, irecv, verbose_check)
-    call toc( "xfer_block_data (finalize_xfer_mpi)", MPI_wtime()-t0 )
+    call toc( "xfer_block_data (finalize_xfer_mpi)", 73, MPI_wtime()-t0 )
 
     ! process-external ghost points (copy from buffer)
     t0 = MPI_wtime()
     call unpack_ghostlayers_external( params, hvy_data, verbose_check )
-    call toc( "xfer_block_data (unpack external)", MPI_wtime()-t0 )
+    call toc( "xfer_block_data (unpack external)", 74, MPI_wtime()-t0 )
 
 end subroutine xfer_block_data
 

--- a/LIB/MPI/xfer_block_data.f90
+++ b/LIB/MPI/xfer_block_data.f90
@@ -7,7 +7,7 @@
 !!    2. Data is send / received via buffers, buffer is assumed to fit all data!
 !!    3. Data is send / received directly (for whole blocks)
 !> Before this step, all metadata and datasizes have to be prepared in send_counter and recv_counter
-subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check)
+subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG)
     ! it is not technically required to include the module here, but for VS code it reduces the number of wrong "errors"
     use module_params
     
@@ -19,16 +19,17 @@ subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check)
 
     logical, optional, intent(in)  :: verbose_check  ! Output verbose flag
 
+    !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
+    real(kind=rk), intent(inout), optional :: hvy_tmp(:, :, :, :, :)
+    integer(kind=ik), intent(in), optional :: REF_FLAG             !< Flag in refinement status when to use hvy_tmp
+
+
     ! Following are global data used but defined in module_mpi:
     !    data_recv_counter, data_send_counter
     !    meta_recv_counter, meta_send_counter
     !    meta_send_all (possibly needs renaming after this function)
 
-    integer(kind=ik)   :: myrank, mpisize, Bs(1:3), buffer_offset
-    integer(kind=ik)   :: k, neighborhood, level_diff
-    integer(kind=ik)   :: recver_rank, recver_hvyID, patch_size
-    integer(kind=ik)   :: sender_hvyID, sender_lgtID
-    integer(kind=ik)   :: ijk(2,3), isend, irecv
+    integer(kind=ik)   :: myrank, mpisize, Bs(1:3), buffer_offset, k, ijk(2,3), isend, irecv
     real(kind=rk)      :: t0
 
     Bs      = params%Bs
@@ -47,24 +48,10 @@ subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check)
     end do
     ! ! test send/receive sizes
     ! if (present(verbose_check)) then
-    !     write(*, '("Rank ", i0, " Send N ", 4(i0, 1x), "Receive N ", 4(i0, 1x), "Send P ", 4(i0, 1x), "Recv P ", 4(i0, 1x), "Send total ", i0)') myrank, data_send_counter, data_recv_counter, meta_send_counter, meta_recv_counter, count_send_total
+        ! write(*, '("Rank ", i0, " Send N ", 4(i0, 1x), "Receive N ", 4(i0, 1x), "Send P ", 4(i0, 1x), "Recv P ", 4(i0, 1x), "Send total ", i0)') myrank, data_send_counter, data_recv_counter, meta_send_counter, meta_recv_counter, count_send_total
     ! endif
 
-    do k = 0, count_send_total-1  ! we do MPI so lets stick to 0-based for a moment
-        recver_rank = meta_send_all(S_META_FULL*k + 3)
-        ! internal relation needs to prepare nothing and will be handled later
-        if ( myrank /= recver_rank ) then
-            ! unpack from metadata array what we need
-            sender_hvyID = meta_send_all(S_META_FULL*k + 1)
-            recver_hvyID = meta_send_all(S_META_FULL*k + 2)
-            neighborhood = meta_send_all(S_META_FULL*k + 4)
-            level_diff = meta_send_all(S_META_FULL*k + 5)
-            patch_size = meta_send_all(S_META_FULL*k + 6)
-
-            ! external relation (MPI communication)
-            call send_prepare_external( params, recver_rank, hvy_data, sender_hvyID, recver_hvyID, neighborhood, level_diff, patch_size, verbose_check)
-        end if
-    end do ! loop over all patches (all heavy_n where neighborhood exists and ghost synching is applied)
+    call send_prepare_external(params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG)
     call toc( "xfer_block_data (prepare data)", MPI_wtime()-t0 )
 
     !***************************************************************************
@@ -79,7 +66,7 @@ subroutine xfer_block_data(params, hvy_data, count_send_total, verbose_check)
     !***************************************************************************
     ! process-internal ghost points (direct copy)
     t0 = MPI_wtime()
-    call unpack_ghostlayers_internal( params, hvy_data, count_send_total, verbose_check)
+    call unpack_ghostlayers_internal( params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG)
     call toc( "xfer_block_data (unpack internal)", MPI_wtime()-t0 )
 
     ! before unpacking the data we received from other ranks, we wait for the transfer
@@ -100,25 +87,31 @@ end subroutine xfer_block_data
 !> \brief Prepare data to be sent with MPI \n
 !! This already applies res_pre so that the recver only has to sort in the data correctly. \n
 !! Fills the send buffer
-subroutine send_prepare_external( params, recver_rank, hvy_data, sender_hvyID, &
-    recver_hvyID, relation, level_diff, patch_size, verbose_check)
+subroutine send_prepare_external( params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG )
     implicit none
 
     type (type_params), intent(in) :: params
-    integer(kind=ik), intent(in)   :: recver_rank ! zero-based
-    integer(kind=ik), intent(in)   :: sender_hvyID, recver_hvyID
-    integer(kind=ik), intent(in)   :: relation  !< neighborhood 1:74, full block 0, family -1:-8
-    integer(kind=ik), intent(in)   :: level_diff
-    integer(kind=ik), intent(in)   :: patch_size
     real(kind=rk), intent(inout)   :: hvy_data(:, :, :, :, :)
     logical, optional, intent(in)  :: verbose_check  ! Output verbose flag
+    integer(kind=ik), intent(in)   :: count_send_total             !< total amount of data to send from this rank
+
+    !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
+    real(kind=rk), intent(inout), optional :: hvy_tmp(:, :, :, :, :)
+    integer(kind=ik), intent(in), optional :: REF_FLAG             !< Flag in refinement status when to use hvy_tmp
+
+    integer(kind=ik)   :: recver_rank, myrank, sender_hvyID, sender_ref, recver_hvyID, level_diff, patch_size, recver_lgtID, sender_lgtID
+    integer(kind=ik)   :: relation  ! neighborhood 1:74, full block 0, family -1:-8
+
+    ! merged information of level diff and an indicator that we have a historic finer sender
+    integer(kind=ik)   :: buffer_offset, buffer_size, data_offset
+    integer(kind=ik)   :: patch_ijk(2,3), size_buff(4), nc, k_patch
+    logical            :: use_hvy_TMP
 
     ! Following are global data used but defined in module_mpi:
     ! res_pre_data, rDara_sendBuffer
 
-    ! merged information of level diff and an indicator that we have a historic finer sender
-    integer(kind=ik)   :: buffer_offset, buffer_size, data_offset
-    integer(kind=ik)   :: patch_ijk(2,3), size_buff(4), nc
+    myrank  = params%rank
+
 
     nc = size(hvy_data,4)
     if (size(res_pre_data,4) < nc) then
@@ -130,55 +123,85 @@ subroutine send_prepare_external( params, recver_rank, hvy_data, sender_hvyID, &
         allocate( res_pre_data(size_buff(1), size_buff(2), size_buff(3), size_buff(4)) )
     endif
 
-    ! NOTE: the indices of ghost nodes data chunks are stored globally in the ijkPatches array (see module_MPI).
-    ! They depend on the neighbor-relation, level difference and the bounds type.
-    ! The last index is 1-sender 2-receiver 3-restricted/predicted.
-    if ( level_diff == 0 .or. relation < 1 ) then
-        ! simply copy the ghost node layer (no interpolation or restriction here) to a line buffer, which
-        ! we will send to our neighbor mpirank
-        patch_ijk = ijkPatches(:,:, relation, level_diff, SENDER)
+    do k_patch = 0, count_send_total-1  ! we do MPI so lets stick to 0-based for a moment
+        recver_rank = meta_send_all(S_META_FULL*k_patch + 4)
+        ! internal relation needs to prepare nothing and will be handled later
+        if ( myrank == recver_rank ) cycle
 
-        call Patch2Line( params, line_buffer, buffer_size, &
-        hvy_data( patch_ijk(1,1):patch_ijk(2,1), patch_ijk(1,2):patch_ijk(2,2), patch_ijk(1,3):patch_ijk(2,3), 1:nc, sender_hvyID) )
+        ! unpack from metadata array what we need
+        sender_hvyID = meta_send_all(S_META_FULL*k_patch + 1)
+        sender_ref = meta_send_all(S_META_FULL*k_patch + 2)
+        recver_hvyID = meta_send_all(S_META_FULL*k_patch + 3)
+        relation = meta_send_all(S_META_FULL*k_patch + 5)
+        level_diff = meta_send_all(S_META_FULL*k_patch + 6)
+        patch_size = meta_send_all(S_META_FULL*k_patch + 7)
 
-    else
-        ! up/downsample data first for neighbor relations, then flatten to 1D buffer
-        patch_ijk = ijkPatches(:,:, relation, level_diff, SENDER)
+        ! check if to use hvy_temp
+        use_hvy_TMP = .false.
+        if (present(hvy_tmp) .and. present(REF_FLAG)) then
+            if (sender_ref /= REF_FLAG) use_hvy_TMP = .true.
+        endif
 
-        call restrict_predict_data( params, res_pre_data, patch_ijk, relation, level_diff, hvy_data, sender_hvyID )
+        ! NOTE: the indices of ghost nodes data chunks are stored globally in the ijkPatches array (see module_MPI).
+        ! They depend on the neighbor-relation, level difference and the bounds type.
+        ! The last index is 1-sender 2-receiver 3-restricted/predicted.
+        if ( level_diff == 0 .or. relation < 1 ) then
+            ! simply copy the ghost node layer (no interpolation or restriction here) to a line buffer, which
+            ! we will send to our neighbor mpirank
+            patch_ijk = ijkPatches(:,:, relation, level_diff, SENDER)
 
-        patch_ijk = ijkPatches(:,:, relation, level_diff, RESPRE)
+            if (use_hvy_TMP) then
+                call Patch2Line( params, line_buffer, buffer_size, &
+                hvy_tmp( patch_ijk(1,1):patch_ijk(2,1), patch_ijk(1,2):patch_ijk(2,2), patch_ijk(1,3):patch_ijk(2,3), 1:nc, sender_hvyID) )
+            else
+                call Patch2Line( params, line_buffer, buffer_size, &
+                hvy_data( patch_ijk(1,1):patch_ijk(2,1), patch_ijk(1,2):patch_ijk(2,2), patch_ijk(1,3):patch_ijk(2,3), 1:nc, sender_hvyID) )
+            endif
 
-        call Patch2Line( params, line_buffer, buffer_size, &
-        res_pre_data( patch_ijk(1,1):patch_ijk(2,1), patch_ijk(1,2):patch_ijk(2,2), patch_ijk(1,3):patch_ijk(2,3), 1:nc) )
-    end if
+        else
+            ! up/downsample data first for neighbor relations, then flatten to 1D buffer
+            patch_ijk = ijkPatches(:,:, relation, level_diff, SENDER)
 
-    ! now append data, first lets find the positions in the array, +1 to skip count number
-    buffer_offset = sum(meta_send_counter(0:recver_rank-1))*S_META_SEND + sum(data_send_counter(0:recver_rank-1)) + recver_rank + 1
-    data_offset = buffer_offset + real_pos(recver_rank)
+            ! when hvy_temp is given but not ref_flag the mode is to use hvy_temp for prediction, this is needed for synching the SC from coarser neighbors
+            if (use_hvy_TMP .or. (present(hvy_tmp) .and. .not. present(REF_FLAG))) then
+                call restrict_predict_data( params, res_pre_data, patch_ijk, relation, level_diff, hvy_tmp, nc, sender_hvyID )
+            else
+                call restrict_predict_data( params, res_pre_data, patch_ijk, relation, level_diff, hvy_data, nc, sender_hvyID )
+            endif
 
-    if (buffer_size /= patch_size) then
-        write(*, '("ERROR: I am confused because real buffer_size is not equivalent to theoretical one:", i0, " - ", i0)') buffer_size, patch_size
-        call abort(666)
-    endif
+            patch_ijk = ijkPatches(:,:, relation, level_diff, RESPRE)
 
-    ! set metadata, encoded in float, as ints up to 2^53 can be exactly represented with doubles this is not a problem
-    rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 1) = recver_hvyID
-    rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 2) = relation
-    rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 3) = level_diff
-    rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 4) = buffer_size
+            call Patch2Line( params, line_buffer, buffer_size, &
+            res_pre_data( patch_ijk(1,1):patch_ijk(2,1), patch_ijk(1,2):patch_ijk(2,2), patch_ijk(1,3):patch_ijk(2,3), 1:nc) )
+        end if
+
+        ! now append data, first lets find the positions in the array, +1 to skip count number
+        buffer_offset = sum(meta_send_counter(0:recver_rank-1))*S_META_SEND + sum(data_send_counter(0:recver_rank-1)) + recver_rank + 1
+        data_offset = buffer_offset + real_pos(recver_rank)
+
+        if (buffer_size /= patch_size) then
+            write(*, '("ERROR: I am confused because real buffer_size is not equivalent to theoretical one:", i0, " - ", i0)') buffer_size, patch_size
+            call abort(666)
+        endif
+
+        ! set metadata, encoded in float, as ints up to 2^53 can be exactly represented with doubles this is not a problem
+        rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 1) = recver_hvyID
+        rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 2) = relation
+        rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 3) = level_diff
+        rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 4) = buffer_size
 #ifdef DEV
-    rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 5) = recver_rank  ! receiver rank only for DEV
+        rData_sendBuffer(buffer_offset + int_pos(recver_rank)*S_META_SEND + 5) = recver_rank  ! receiver rank only for DEV
 #endif
 
-    ! set data
-    if (buffer_size>0) then
-        rData_sendBuffer( data_offset:data_offset+buffer_size-1 ) = line_buffer(1:buffer_size)
-    endif
+        ! set data
+        if (buffer_size>0) then
+            rData_sendBuffer( data_offset:data_offset+buffer_size-1 ) = line_buffer(1:buffer_size)
+        endif
 
-    ! shift positions
-    real_pos(recver_rank) = real_pos(recver_rank) + buffer_size
-    int_pos(recver_rank) = int_pos(recver_rank) + 1
+        ! shift positions
+        real_pos(recver_rank) = real_pos(recver_rank) + buffer_size
+        int_pos(recver_rank) = int_pos(recver_rank) + 1
+    end do ! loop over all patches (all heavy_n where neighborhood exists and ghost synching is applied)
 
 end subroutine send_prepare_external
 
@@ -251,34 +274,45 @@ end subroutine unpack_ghostlayers_external
 
 !> \brief Unpack all internal patches which do not have to be sent
 !! This simply copies from hvy_data, applies res_pre and then copies it back into the correct position
-subroutine unpack_ghostlayers_internal( params, hvy_data, count_send_total, verbose_check )
+subroutine unpack_ghostlayers_internal( params, hvy_data, count_send_total, verbose_check, hvy_tmp, REF_FLAG )
     implicit none
 
     type (type_params), intent(in)      :: params
     real(kind=rk), intent(inout)        :: hvy_data(:, :, :, :, :)
     integer(kind=ik), intent(in)        :: count_send_total  !< total amount of patches for do loop
     logical, optional, intent(in)  :: verbose_check  ! Output verbose flag
+    !> heavy temp data array - block data of preserved values before the WD, used in adapt_tree as neighbours already might be wavelet decomposed
+    real(kind=rk), intent(inout), optional :: hvy_tmp(:, :, :, :, :)
+    integer(kind=ik), intent(in), optional :: REF_FLAG             !< Flag in refinement status when to use hvy_tmp
 
-    integer(kind=ik) :: k_patch, recver_rank, recver_hvyID, recver_lgtID, sender_lgtID
+    integer(kind=ik) :: k_patch, recver_rank, recver_hvyID, recver_lgtID, sender_lgtID, sender_ref
     integer(kind=ik) :: relation  !< neighborhood 1:74, full block 0, family -1:-8
     integer(kind=ik) :: sender_hvyID, level_diff
     integer(kind=ik) :: send_ijk(2,3), recv_ijk(2,3), nc, myrank
+    logical          :: use_hvy_tmp
 
     nc = size(hvy_data,4)
     myrank  = params%rank
 
     do k_patch = 0, count_send_total-1
         ! check if this ghost point patch is addressed from me to me
-        recver_rank = meta_send_all(S_META_FULL*k_patch + 3)
+        recver_rank = meta_send_all(S_META_FULL*k_patch + 4)
         if (recver_rank == myrank) then
             ! unpack required info:  sender_hvyID, recver_hvyID, neighborhood, level_diff
             sender_hvyID = meta_send_all(S_META_FULL*k_patch + 1)
-            recver_hvyID = meta_send_all(S_META_FULL*k_patch + 2)
-            relation     = meta_send_all(S_META_FULL*k_patch + 4)
-            level_diff   = meta_send_all(S_META_FULL*k_patch + 5)
+            sender_ref =   meta_send_all(S_META_FULL*k_patch + 2)
+            recver_hvyID = meta_send_all(S_META_FULL*k_patch + 3)
+            relation     = meta_send_all(S_META_FULL*k_patch + 5)
+            level_diff   = meta_send_all(S_META_FULL*k_patch + 6)
 
             call hvy2lgt( sender_lgtID, sender_hvyID, myrank, params%number_blocks )
             call hvy2lgt( recver_lgtID, recver_hvyID, myrank, params%number_blocks )
+
+            use_hvy_tmp = .false.
+            if (present(hvy_tmp) .and. present(REF_FLAG)) then
+                if (sender_ref /= REF_FLAG) use_hvy_tmp = .true.
+            endif
+
 
             if ( level_diff == 0  .or. relation < 1 ) then
                 ! simply copy from sender block to receiver block (NOTE: both are on the same MPIRANK)
@@ -288,12 +322,23 @@ subroutine unpack_ghostlayers_internal( params, hvy_data, count_send_total, verb
                 send_ijk = ijkPatches(:,:, relation, level_diff, RECVER)
                 recv_ijk = ijkPatches(:,:, relation, level_diff, SENDER)
 
-                hvy_data( send_ijk(1,1):send_ijk(2,1), send_ijk(1,2):send_ijk(2,2), send_ijk(1,3):send_ijk(2,3), 1:nc, recver_hvyID ) = &
-                hvy_data( recv_ijk(1,1):recv_ijk(2,1), recv_ijk(1,2):recv_ijk(2,2), recv_ijk(1,3):recv_ijk(2,3), 1:nc, sender_hvyID)
+                if (use_hvy_tmp) then
+                    hvy_data( send_ijk(1,1):send_ijk(2,1), send_ijk(1,2):send_ijk(2,2), send_ijk(1,3):send_ijk(2,3), 1:nc, recver_hvyID ) = &
+                    hvy_tmp( recv_ijk(1,1):recv_ijk(2,1), recv_ijk(1,2):recv_ijk(2,2), recv_ijk(1,3):recv_ijk(2,3), 1:nc, sender_hvyID)
+                else
+                    hvy_data( send_ijk(1,1):send_ijk(2,1), send_ijk(1,2):send_ijk(2,2), send_ijk(1,3):send_ijk(2,3), 1:nc, recver_hvyID ) = &
+                    hvy_data( recv_ijk(1,1):recv_ijk(2,1), recv_ijk(1,2):recv_ijk(2,2), recv_ijk(1,3):recv_ijk(2,3), 1:nc, sender_hvyID)
+                endif
             else
                 ! interpolation or restriction before inserting
-                call restrict_predict_data( params, res_pre_data, ijkPatches(1:2,1:3, relation, level_diff, SENDER), &
-                relation, level_diff, hvy_data, sender_hvyID )
+                ! when hvy_temp is given but not ref_flag the mode is to use hvy_temp for prediction, this is needed for synching the SC from coarser neighbors
+                if (use_hvy_tmp .or. (present(hvy_tmp) .and. .not. present(REF_FLAG))) then
+                    call restrict_predict_data( params, res_pre_data, ijkPatches(1:2,1:3, relation, level_diff, SENDER), &
+                    relation, level_diff, hvy_tmp, nc, sender_hvyID )
+                else
+                    call restrict_predict_data( params, res_pre_data, ijkPatches(1:2,1:3, relation, level_diff, SENDER), &
+                    relation, level_diff, hvy_data, nc, sender_hvyID )
+                endif
     
                 ! copy interpolated / restricted data to ghost nodes layer
                 ! NOTE: the indices of ghost nodes data chunks are stored globally in the ijkPatches array (see module_MPI).
@@ -511,7 +556,7 @@ subroutine prepare_update_family_metadata(params, lgt_block, hvy_family, hvy_act
     !    meta_recv_counter, meta_send_counter
     !    meta_send_all (possibly needs renaming after this function)
 
-    integer(kind=ik) :: k_block, sender_hvyID, sender_lgtID, myrank, mylastdigit, N, family, recver_rank
+    integer(kind=ik) :: k_block, sender_hvyID, sender_lgtID, sender_ref, myrank, mylastdigit, N, family, recver_rank
     integer(kind=ik) :: ijk(2,3), inverse, ierr, recver_hvyID, recver_lgtID, level, level_diff, status, new_size
     integer(kind=tsize) :: tc
 
@@ -554,6 +599,7 @@ subroutine prepare_update_family_metadata(params, lgt_block, hvy_family, hvy_act
         level = lgt_block( sender_lgtID, IDX_MESH_LVL )
         tc = get_tc(lgt_block(sender_lgtID, IDX_TC_1 : IDX_TC_2))
         mylastdigit = tc_get_digit_at_level_b(tc, dim=params%dim, level=level, max_level=params%Jmax)
+        sender_ref = lgt_block( sender_lgtID, IDX_REFINE_STS)
 
         ! check if mother exists
         if (hvy_family(sender_hvyID, 1) /= -1) then
@@ -588,11 +634,12 @@ subroutine prepare_update_family_metadata(params, lgt_block, hvy_family, hvy_act
 
                 ! now lets save all metadata in one array without caring for rank sorting for now
                 meta_send_all(S_META_FULL*count_send + 1) = sender_hvyID  ! needed for same-rank sending
-                meta_send_all(S_META_FULL*count_send + 2) = recver_hvyID
-                meta_send_all(S_META_FULL*count_send + 3) = recver_rank
-                meta_send_all(S_META_FULL*count_send + 4) = -1 - mylastdigit
-                meta_send_all(S_META_FULL*count_send + 5) = -1  ! inverse as adjusted to receiver
-                meta_send_all(S_META_FULL*count_send + 6) = (ijk(2,1)-ijk(1,1)+1) * (ijk(2,2)-ijk(1,2)+1) * (ijk(2,3)-ijk(1,3)+1) * ncomponents
+                meta_send_all(S_META_FULL*count_send + 2) = sender_ref    ! needed for hvy_tmp for adapt_tree
+                meta_send_all(S_META_FULL*count_send + 3) = recver_hvyID
+                meta_send_all(S_META_FULL*count_send + 4) = recver_rank
+                meta_send_all(S_META_FULL*count_send + 5) = -1 - mylastdigit
+                meta_send_all(S_META_FULL*count_send + 6) = -1  ! inverse as adjusted to receiver
+                meta_send_all(S_META_FULL*count_send + 7) = (ijk(2,1)-ijk(1,1)+1) * (ijk(2,2)-ijk(1,2)+1) * (ijk(2,3)-ijk(1,3)+1) * ncomponents
                 
                 count_send = count_send + 1
             endif
@@ -659,11 +706,12 @@ subroutine prepare_update_family_metadata(params, lgt_block, hvy_family, hvy_act
 
                     ! now lets save all metadata in one array without caring for rank sorting for now
                     meta_send_all(S_META_FULL*count_send + 1) = sender_hvyID  ! needed for same-rank sending
-                    meta_send_all(S_META_FULL*count_send + 2) = recver_hvyID
-                    meta_send_all(S_META_FULL*count_send + 3) = recver_rank
-                    meta_send_all(S_META_FULL*count_send + 4) = -family
-                    meta_send_all(S_META_FULL*count_send + 5) = 1  ! inverse as adjusted to receiver
-                    meta_send_all(S_META_FULL*count_send + 6) = (ijk(2,1)-ijk(1,1)+1) * (ijk(2,2)-ijk(1,2)+1) * (ijk(2,3)-ijk(1,3)+1) * ncomponents
+                    meta_send_all(S_META_FULL*count_send + 2) = sender_ref    ! needed for hvy_tmp for adapt_tree
+                    meta_send_all(S_META_FULL*count_send + 3) = recver_hvyID
+                    meta_send_all(S_META_FULL*count_send + 4) = recver_rank
+                    meta_send_all(S_META_FULL*count_send + 5) = -family
+                    meta_send_all(S_META_FULL*count_send + 6) = 1  ! inverse as adjusted to receiver
+                    meta_send_all(S_META_FULL*count_send + 7) = (ijk(2,1)-ijk(1,1)+1) * (ijk(2,2)-ijk(1,2)+1) * (ijk(2,3)-ijk(1,3)+1) * ncomponents
                     
                     count_send = count_send + 1
                 endif

--- a/LIB/POSTPROCESSING/compute_scalar_field_post.f90
+++ b/LIB/POSTPROCESSING/compute_scalar_field_post.f90
@@ -111,7 +111,7 @@ subroutine compute_scalar_field_post(params)
     ! update neighbor relations
     call updateNeighbors_tree(params, tree_ID)
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     ! calculate vorticity from velocities
     do k = 1, hvy_n(tree_ID)

--- a/LIB/POSTPROCESSING/compute_vorticity_post.f90
+++ b/LIB/POSTPROCESSING/compute_vorticity_post.f90
@@ -155,7 +155,7 @@ subroutine compute_vorticity_post(params)
         call readHDF5vct_tree( (/file_ux, file_uy/), params, hvy_block, tree_ID)
     end if
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+    call sync_ghosts_tree( params, hvy_block, tree_ID)
 
     ! calculate vorticity from velocities
     do k = 1, hvy_n(tree_ID)
@@ -545,8 +545,7 @@ end subroutine
 !     ! read input data
 !     call readHDF5vct_tree( (/fname1, fname2/), params, hvy_block, tree_ID)
 !
-!     ! call sync_ghosts( params, lgt_block, hvy_block, hvy_neighbor, &
-!     ! hvy_active(:,tree_ID), hvy_n(tree_ID) )
+!     ! call sync_ghosts_tree( params, hvy_block, tree_ID )
 !
 !
 !     do k = 1, hvy_n(tree_ID)
@@ -572,8 +571,7 @@ end subroutine
 !         ! call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
 !     end do
 !
-!     call sync_ghosts( params, lgt_block, hvy_block, hvy_neighbor, &
-!     hvy_active(:,tree_ID), hvy_n(tree_ID) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID )
 !
 !     do k = 1, hvy_n(tree_ID)
 !         hvyID = hvy_active(k,tree_ID)
@@ -590,8 +588,7 @@ end subroutine
 !     !     call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
 !     ! end do
 !     !
-!     ! call sync_ghosts( params, lgt_block, hvy_block, hvy_neighbor, &
-!     ! hvy_active(:,tree_ID), hvy_n(tree_ID) )
+!     ! call sync_ghosts_tree( params, hvy_block, tree_ID )
 !     !
 !     ! do k = 1, hvy_n(tree_ID)
 !     !     hvyID = hvy_active(k,tree_ID)
@@ -746,7 +743,7 @@ subroutine wavelet_test_coarsening(params)
 do iter= 1, 1
 
     ! compute FWT
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     do k = 1, hvy_n(tree_ID)
         hvyID = hvy_active(k,tree_ID)
@@ -861,7 +858,7 @@ do iter= 1, 1
 
 
     ! wc are modified - we have to sync
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
 
     do k = 1, hvy_n(tree_ID)
@@ -870,7 +867,7 @@ do iter= 1, 1
     end do
 
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     ! call executeCoarsening_tree( params, hvy_block, tree_ID, .true. )
     call abort(150623, "we removed the ignore_prefilter, check if that is okay still")
@@ -900,14 +897,14 @@ call readHDF5vct_tree( (/"coarsening_331.h5"/), params, hvy_block, tree_ID)
 do iter= 1, 1
 
     ! compute FWT
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     do k = 1, hvy_n(tree_ID)
         hvyID = hvy_active(k,tree_ID)
         call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvyID))
     end do
 
-    ! call sync_ghosts( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    ! call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     ! flag for coarsening
     do k = 1, lgt_n(tree_ID)
@@ -960,7 +957,7 @@ do iter= 1, 1
 
 
     ! wc are modified - we have to sync
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
 
     do k = 1, hvy_n(tree_ID)
@@ -969,7 +966,7 @@ do iter= 1, 1
     end do
 
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     call executeCoarsening_tree( params, hvy_block, tree_ID )
     call abort(150623, "we removed the ignore_prefilter, check if that is okay still")

--- a/LIB/POSTPROCESSING/mask_post.f90
+++ b/LIB/POSTPROCESSING/mask_post.f90
@@ -74,7 +74,7 @@ subroutine mask_post(params)
     ! update list of sorted nunmerical treecodes, used for finding blocks
     call updateMetadata_tree(params, tree_ID)
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     if (.not. allocated(us)) allocate(us(1:Bs(1)+2*g, 1:Bs(2)+2*g, 1:Bs(3)+2*g, 1:3))
 

--- a/LIB/POSTPROCESSING/module_MOR.f90
+++ b/LIB/POSTPROCESSING/module_MOR.f90
@@ -616,9 +616,9 @@ contains
             call snapshot_POD( params, hvy_block, hvy_tmp, truncation_error, truncation_rank, save_all)
         endif
         t_elapse(2) = MPI_Wtime()-t_elapse(2)
-        call toc( "post_POD (read + coarse): ", t_elapse(1) )
-        call toc( "post_POD (snapshot_POD): ", t_elapse(2) )
-        call toc( "post_POD (total wPOD algo): ", t_elapse(1) + t_elapse(2) )
+        call toc( "post_POD (read + coarse): ", 350, t_elapse(1) )
+        call toc( "post_POD (snapshot_POD): ", 351, t_elapse(2) )
+        call toc( "post_POD (total wPOD algo): ", 352, t_elapse(1) + t_elapse(2) )
 
     end subroutine
     !##############################################################
@@ -1152,7 +1152,7 @@ contains
         C = C / Volume
         C = C / real(N_snapshots,kind=rk)
 
-        call toc( "compute_covariance_matrix", MPI_WTIME() - t_elapse )
+        call toc( "compute_covariance_matrix", 353, MPI_WTIME() - t_elapse )
 
     end subroutine
     !##############################################################

--- a/LIB/POSTPROCESSING/module_MOR.f90
+++ b/LIB/POSTPROCESSING/module_MOR.f90
@@ -1520,7 +1520,7 @@ contains
             if ( params%adapt_tree) then
                 call adapt_tree( 0.0_rk, params, hvy_block, dest_tree_ID, params%coarsening_indicator, hvy_tmp )
             else
-                call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:, dest_tree_ID), hvy_n(dest_tree_ID))
+                call sync_ghosts_tree( params, hvy_block, dest_tree_ID)
             endif
 
             t_elapse = MPI_WTIME() - t_elapse

--- a/LIB/POSTPROCESSING/mult_mask.f90
+++ b/LIB/POSTPROCESSING/mult_mask.f90
@@ -113,7 +113,7 @@ subroutine mult_mask(params)
     ! update list of sorted nunmerical treecodes, used for finding blocks
     call updateMetadata_tree( params, tree_ID)
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     ! calculate product
     if (operation == "--mult-mask" .or. operation == "--mult-mask-inverse") then

--- a/LIB/POSTPROCESSING/operator_reconstruction.f90
+++ b/LIB/POSTPROCESSING/operator_reconstruction.f90
@@ -248,14 +248,14 @@ subroutine operator_reconstruction(params)
             !---------------------------------------------------------------
             ! synchronize ghosts. This was done for the redundantGrid -> check if still required for the uniqueGrid (as of 2023)
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+            call sync_ghosts_tree(params, hvy_block, tree_ID)
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
             if (refine) then
 call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
 !                call refine_tree( params, hvy_block, "everywhere", tree_ID )
 
-                call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+                call sync_ghosts_tree(params, hvy_block, tree_ID)
             endif
 
 
@@ -294,13 +294,13 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
             ! on the coarse and fine level. This synchronizing step lets us keep only either of those,
             ! depending on fineWins or coarseWins
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+            call sync_ghosts_tree(params, hvy_block, tree_ID)
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
             if (refine) then
                 call adapt_tree( time, params, hvy_block, tree_ID_flow, "everywhere", hvy_tmp )
 
-                call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+                call sync_ghosts_tree(params, hvy_block, tree_ID)
             endif
 
 

--- a/LIB/POSTPROCESSING/performance_test.f90
+++ b/LIB/POSTPROCESSING/performance_test.f90
@@ -83,7 +83,7 @@ subroutine performance_test(params)
             ! refine everywhere
             t4 = MPI_wtime()
             if ( params%adapt_tree ) then
-                call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+                call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 
 call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 ! call refine_tree( params, hvy_block, "everywhere", tree_ID=tree_ID_flow )

--- a/LIB/POSTPROCESSING/performance_test.f90
+++ b/LIB/POSTPROCESSING/performance_test.f90
@@ -88,7 +88,7 @@ subroutine performance_test(params)
 call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 ! call refine_tree( params, hvy_block, "everywhere", tree_ID=tree_ID_flow )
             endif
-            call toc( "TOPLEVEL: refinement", MPI_wtime()-t4)
+            call toc( "TOPLEVEL: refinement", 10, MPI_wtime()-t4)
             Nblocks_rhs = lgt_n(tree_ID_flow)
 
 
@@ -97,7 +97,7 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
             do it = 1, params%N_dt_per_grid
                 t4 = MPI_wtime()
                 call timeStep_tree( time, dt, iteration, params, hvy_block, hvy_work, hvy_mask, hvy_tmp, tree_ID=tree_ID_flow )
-                call toc( "TOPLEVEL: time stepper", MPI_wtime()-t4)
+                call toc( "TOPLEVEL: time stepper", 11, MPI_wtime()-t4)
             enddo
 
             ! Adapt mesh (coarsening where possible)
@@ -106,7 +106,7 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 ! actual coarsening
                 call adapt_tree( time, params, hvy_block, tree_ID_flow, "everywhere", hvy_tmp )
             endif
-            call toc( "TOPLEVEL: adapt mesh", MPI_wtime()-t4)
+            call toc( "TOPLEVEL: adapt mesh", 13, MPI_wtime()-t4)
             Nblocks = lgt_n(tree_ID_flow)
 
             t0_timesteps(j) = MPI_wtime() - t0

--- a/LIB/POSTPROCESSING/post_compression_unit_test.f90
+++ b/LIB/POSTPROCESSING/post_compression_unit_test.f90
@@ -153,7 +153,7 @@ subroutine post_compression_unit_test(params)
         !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
         ! (2) compress it with the wavelet and threshold paras%eps
         !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+        call sync_ghosts_tree( params, hvy_block, tree_ID)
         call adapt_tree( 0.0_rk, params, hvy_block, tree_ID, params%coarsening_indicator, hvy_tmp)
         
         Nb = lgt_n(tree_ID)
@@ -161,7 +161,7 @@ subroutine post_compression_unit_test(params)
         !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
         ! (3) refine if back to the original resolution
         !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+        call sync_ghosts_tree( params, hvy_block, tree_ID)
         call refineToEquidistant_tree(params, hvy_block, hvy_tmp, tree_ID, params%Jmax)
 
         !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+

--- a/LIB/POSTPROCESSING/post_dry_run.f90
+++ b/LIB/POSTPROCESSING/post_dry_run.f90
@@ -190,7 +190,7 @@ subroutine post_dry_run
             ! Note: at this point the grid is rather coarse (fewer blocks), and the sync step is rather cheap.
             ! Snyc'ing becomes much more expensive once the grid is refined.
             ! sync possible only before pruning
-            call sync_ghosts_all( params, lgt_block, hvy_mask, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+            call sync_ghosts_tree( params, hvy_mask, tree_ID_flow )
 
 
             ! refine the mesh, but only where the mask is interesting (not everywhere!)
@@ -229,8 +229,7 @@ subroutine post_dry_run
         call WRITE_INSECT_DATA(time)
 
         ! before (possible) pruning, we sync the ghosts
-        call sync_ghosts_all( params, lgt_block, hvy_mask, hvy_neighbor, &
-        hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+        call sync_ghosts_tree( params, hvy_mask, tree_ID_flow )
 
         if (pruned) then
             if (params%rank==0) write(*,*) "now pruning!"

--- a/LIB/POSTPROCESSING/post_evaluate_thresholding.f90
+++ b/LIB/POSTPROCESSING/post_evaluate_thresholding.f90
@@ -129,7 +129,8 @@ subroutine post_evaluate_thresholding(params)
 
     do level = Jmax_active, Jmin_active, -1
         write(*,*) level
-        call coarseningIndicator_level( time, params, level, hvy_block, hvy_tmp, tree_ID, params%coarsening_indicator, iteration, ignore_maxlevel=.true., input_is_WD=.false.)
+        call coarseningIndicator_tree( time, params, level, hvy_block, hvy_tmp, tree_ID, params%coarsening_indicator, iteration, &
+            ignore_maxlevel=.true., input_is_WD=.false., check_ref_TMP=.false.)
     enddo
 
 

--- a/LIB/POSTPROCESSING/post_evaluate_thresholding.f90
+++ b/LIB/POSTPROCESSING/post_evaluate_thresholding.f90
@@ -121,7 +121,7 @@ subroutine post_evaluate_thresholding(params)
     ! read input data
     call readHDF5vct_tree( (/fname/), params, hvy_block, tree_ID)
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID))
+    call sync_ghosts_tree( params, hvy_block, tree_ID)
 
 
     Jmin_active = minActiveLevel_tree(tree_ID)

--- a/LIB/POSTPROCESSING/post_extract_slice.f90
+++ b/LIB/POSTPROCESSING/post_extract_slice.f90
@@ -88,7 +88,7 @@ subroutine post_extract_slice(params)
 
     call updateMetadata_tree(params, tree_ID)
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     Nblocks = 0
     do k = 1, hvy_n(tree_ID)

--- a/LIB/POSTPROCESSING/post_filtertest.f90
+++ b/LIB/POSTPROCESSING/post_filtertest.f90
@@ -62,12 +62,12 @@ subroutine post_filtertest(params)
 !
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! ! to get a mesh where coarsening is possible evrywhere refine one time
-! call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+! call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 ! call refine_tree( params, lgt_block, hvy_block, hvy_neighbor, lgt_active, lgt_n, &
 ! lgt_sortednumlist, hvy_active, hvy_n, "everywhere", tree_ID=tree_ID_flow )
 !
-! call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+! call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! do k = 1, hvy_n(tree_ID_flow)
 !     !!!!!!!
@@ -89,16 +89,16 @@ subroutine post_filtertest(params)
 ! enddo
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
-!     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 !     call saveHDF5_tree("input_000020000000.h5", time, iteration, 1, params, lgt_block, hvy_block, lgt_active(:,tree_ID_flow),&
 !     lgt_n(tree_ID_flow), hvy_n(tree_ID_flow), hvy_active(:,tree_ID_flow) )
 !
-!     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 !     call filter_wrapper(time, params, hvy_block, hvy_tmp, hvy_mask, lgt_block, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow), hvy_neighbor)
 !
-!     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 !     call saveHDF5_tree("filter_000020000000.h5", time, iteration, 1, params, lgt_block, hvy_block, lgt_active(:,tree_ID_flow),&
 !     lgt_n(tree_ID_flow), hvy_n(tree_ID_flow), hvy_active(:,tree_ID_flow) )
@@ -122,19 +122,19 @@ subroutine post_filtertest(params)
 !     call updateMetadata_tree(params, lgt_block, hvy_neighbor, lgt_active, &
 !     lgt_n, lgt_sortednumlist, hvy_active, hvy_n, tree_ID_flow)
 !
-!     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 !     call adapt_tree( time, params, lgt_block, hvy_block, hvy_neighbor, lgt_active, &
 !     lgt_n, lgt_sortednumlist, hvy_active, hvy_n, tree_ID_flow, "everywhere", hvy_tmp=hvy_tmp, ignore_maxlevel=.true. )
 !
 !     write(*,*) "adapted to=", lgt_n(tree_ID_flow)
 !
-!     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 !     call refine_tree( params, lgt_block, hvy_block, hvy_neighbor, lgt_active, lgt_n, &
 !     lgt_sortednumlist, hvy_active, hvy_n, "everywhere", tree_ID=tree_ID_flow )
 !
-!     call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_flow), hvy_n(tree_ID_flow) )
+!     call sync_ghosts_tree( params, hvy_block, tree_ID_flow )
 !
 !     write(*,*) "refined to=", lgt_n(tree_ID_flow)
 !

--- a/LIB/POSTPROCESSING/post_rhs.f90
+++ b/LIB/POSTPROCESSING/post_rhs.f90
@@ -87,7 +87,7 @@ subroutine post_rhs(params)
     ! balance the load
     call balanceLoad_tree(params, hvy_block, tree_ID)
 
-    call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree(params, hvy_block, tree_ID )
 
     ! compute right hand side
     call RHS_wrapper(time, params, hvy_block, hvy_work(:,:,:,:,:,1), hvy_mask, hvy_tmp, tree_ID)

--- a/LIB/POSTPROCESSING/rhs_operator_reconstruction.f90
+++ b/LIB/POSTPROCESSING/rhs_operator_reconstruction.f90
@@ -140,12 +140,12 @@ subroutine rhs_operator_reconstruction(params)
 
     ! this hack ensures, on mono_CPU, that later on, refine+coarsening always ends up in the same order in hvy_actve
     if (params%adapt_tree) then
-        call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_u), hvy_n(tree_ID_u))
+        call sync_ghosts_tree(params, hvy_block, tree_ID_u)
 
 call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
         ! call refine_tree( params, hvy_block, "everywhere", tree_ID=tree_ID_u )
 
-        call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_u), hvy_n(tree_ID_u))
+        call sync_ghosts_tree(params, hvy_block, tree_ID_u)
 
         call adapt_tree( time, params, hvy_block, tree_ID_u, "everywhere", hvy_tmp )
 
@@ -212,11 +212,11 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
         !---------------------------------------------------------------------------
         ! refine grid ones
         !---------------------------------------------------------------------------
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_tmp), hvy_n(tree_ID_tmp) )
+        call sync_ghosts_tree( params, hvy_block, tree_ID_tmp )
 call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
         ! call refine_tree( params, hvy_block, "everywhere", tree_ID=tree_ID_tmp )
 
-        call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_tmp), hvy_n(tree_ID_tmp))
+        call sync_ghosts_tree(params, hvy_block, tree_ID_tmp)
     endif
 
     hvy_work(:,:,:,:,:,1) = 0
@@ -269,7 +269,7 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
                 if ( params%adapt_tree ) then
-                    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_ei), hvy_n(tree_ID_ei) )
+                    call sync_ghosts_tree( params, hvy_block, tree_ID_ei )
 call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                     ! call refine_tree( params, hvy_block, "everywhere", tree_ID=tree_ID_ei )
 
@@ -282,7 +282,7 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 ! In fact, each point is then computed only once. Note: if you set the point on a high lgt_id, then
                 ! it will be "sync'ed down" to lower light IDs, so you can find the point more than once
                 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-                call sync_ghosts_all(params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID_ei), hvy_n(tree_ID_ei))
+                call sync_ghosts_tree(params, hvy_block, tree_ID_ei)
                 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 ! Now compute rhs(u+he_i) of the derivative 1/h[rhs(u + h* e_i) - rhs(u)]
                 ! call RHS_wrapper(time, params, hvy_block, hvy_work(:,:,:,:,:,1), hvy_mask, hvy_tmp, lgt_block, &
@@ -306,8 +306,8 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 ! Note that on a coarse/fine interface, wabbit computes two values for the derivative
                 ! on the coarse and fine level. This synchronizing step lets us keep only either of those,
                 ! depending on fineWins or coarseWins
-                call sync_ghosts_all(params, lgt_block, hvy_work(:,:,:,:,:,1), hvy_neighbor, hvy_active(:,tree_ID_ei), hvy_n(tree_ID_ei))
-                call sync_ghosts_all(params, lgt_block, hvy_work(:,:,:,:,:,1), hvy_neighbor, hvy_active(:,tree_ID_rhs_u), hvy_n(tree_ID_rhs_u))
+                call sync_ghosts_tree(params, hvy_work(:,:,:,:,:,1), tree_ID_ei)
+                call sync_ghosts_tree(params, hvy_work(:,:,:,:,:,1), tree_ID_rhs_u)
 
                 call delete_tree(params, tree_ID_rhs_u_ei)
                 call substract_two_trees(params, hvy_work(:,:,:,:,:,1), hvy_tmp, tree_ID1=tree_ID_ei, tree_ID2=tree_ID_rhs_u, dest_tree_ID=tree_ID_rhs_u_ei)
@@ -320,7 +320,7 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
                 if ( params%adapt_tree ) then
                     call updateMetadata_tree(params, tree_ID_rhs_u_ei)
 
-                    call sync_ghosts_all(params, lgt_block, hvy_work(:,:,:,:,:,1), hvy_neighbor, hvy_active(:,tree_ID_rhs_u_ei), hvy_n(tree_ID_rhs_u_ei))
+                    call sync_ghosts_tree(params, hvy_work(:,:,:,:,:,1), tree_ID_rhs_u_ei)
                     ! call adapt_tree( time, params, lgt_block, hvy_work(:,:,:,:,:,1), hvy_neighbor, lgt_active(:,tree_ID_rhs_u_ei), &
                     !  lgt_n(tree_ID_rhs_u_ei), lgt_sortednumlist(:,:,tree_ID_rhs_u_ei), hvy_active(:,tree_ID_rhs_u_ei), hvy_n(tree_ID_rhs_u_ei), tree_ID_rhs_u_ei, "everywhere", hvy_tmp, external_loop=.true. )
 
@@ -329,7 +329,7 @@ call abort(99999, "need to adapt refine_tree call to include hvy_tmp")
 
                     call updateMetadata_tree(params, tree_ID_rhs_u_ei)
 
-                    call sync_ghosts_all(params, lgt_block, hvy_work(:,:,:,:,:,1), hvy_neighbor, hvy_active(:,tree_ID_rhs_u_ei), hvy_n(tree_ID_rhs_u_ei))
+                    call sync_ghosts_tree(params, hvy_work(:,:,:,:,:,1), tree_ID_rhs_u_ei)
                 endif
                 ! save operator line to text file.
                 ! note: unfortunately, we use the index on the finest level, i.e., we temporarily

--- a/LIB/POSTPROCESSING/sparse_to_dense.f90
+++ b/LIB/POSTPROCESSING/sparse_to_dense.f90
@@ -155,7 +155,7 @@ subroutine sparse_to_dense(params)
     ! balance the load
     call balanceLoad_tree(params, hvy_block, tree_ID)
 
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID) )
+    call sync_ghosts_tree( params, hvy_block, tree_ID )
 
     if (operator=="sparse-to-dense") then
         call refineToEquidistant_tree(params, hvy_block, hvy_tmp, tree_ID, target_level=level)

--- a/LIB/TIME/RHS_wrapper.f90
+++ b/LIB/TIME/RHS_wrapper.f90
@@ -50,7 +50,7 @@ subroutine RHS_wrapper(time, params, hvy_block, hvy_rhs, hvy_mask, hvy_tmp, tree
     !-------------------------------------------------------------------------
     t1 = MPI_wtime()
     call createMask_tree(params, time, hvy_mask, hvy_tmp)
-    call toc( "RHS_wrapper::createMask_tree", MPI_wtime()-t1 )
+    call toc( "RHS_wrapper::createMask_tree", 21, MPI_wtime()-t1 )
 
 
     !-------------------------------------------------------------------------
@@ -94,7 +94,7 @@ subroutine RHS_wrapper(time, params, hvy_block, hvy_rhs, hvy_mask, hvy_tmp, tree
     hvy_id = hvy_active(1, tree_ID) ! for this stage, just pass any block (result does not depend on block)
     call RHS_meta( params%physics_type, time, hvy_block(:,:,:,:, hvy_id), g, x0, dx, &
     hvy_rhs(:,:,:,:,hvy_id), hvy_mask(:,:,:,:,hvy_id), "post_stage" )
-    call toc( "RHS_wrapper::integral-stage", MPI_wtime()-t1 )
+    call toc( "RHS_wrapper::integral-stage", 22, MPI_wtime()-t1 )
 
 
     !-------------------------------------------------------------------------
@@ -119,7 +119,7 @@ subroutine RHS_wrapper(time, params, hvy_block, hvy_rhs, hvy_mask, hvy_tmp, tree
         call RHS_meta( params%physics_type, time, hvy_block(:,:,:,:, hvy_id), g, &
         x0, dx, hvy_rhs(:,:,:,:, hvy_id), hvy_mask(:,:,:,:, hvy_id), "local_stage", n_domain)
     enddo
-    call toc( "RHS_wrapper::local-stage", MPI_wtime()-t1 )
+    call toc( "RHS_wrapper::local-stage", 23, MPI_wtime()-t1 )
 
-    call toc( "RHS_wrapper_ALL", MPI_wtime()-t0 )
+    call toc( "RHS_wrapper (TOTAL)", 20, MPI_wtime()-t0 )
 end subroutine RHS_wrapper

--- a/LIB/TIME/krylov.f90
+++ b/LIB/TIME/krylov.f90
@@ -128,7 +128,7 @@ subroutine krylov_time_stepper(time, dt, iteration, params, hvy_block, hvy_work,
             t0 = MPI_wtime()
             phiMat(1:M_iter+2, 1:M_iter+2) = expM_pade( dt*H_tmp(1:M_iter+2, 1:M_iter+2) )
             phiMat(M_iter+1, M_iter+1)     = h_klein*phiMat(M_iter, M_iter+2)
-            call toc( "Krylov: matrix exponential", MPI_wtime()-t0)
+            call toc( "Krylov: matrix exponential", 24, MPI_wtime()-t0)
 
 
             ! *** Error estimate ***!

--- a/LIB/TIME/krylov.f90
+++ b/LIB/TIME/krylov.f90
@@ -43,7 +43,7 @@ subroutine krylov_time_stepper(time, dt, iteration, params, hvy_block, hvy_work,
     endif
 
     ! synchronize ghost nodes
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs )
+    call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs )
 
     ! calculate time step
     call calculate_time_step(params, time, iteration, hvy_block, dt, tree_ID)
@@ -81,7 +81,7 @@ subroutine krylov_time_stepper(time, dt, iteration, params, hvy_block, hvy_work,
         enddo
 
         ! call RHS with perturbed state vector, stored in slot (M_max+1)
-        call sync_ghosts_all( params, lgt_block, hvy_work(:,:,:,:,:,M_max+2), hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs  )
+        call sync_ghosts_tree( params, hvy_work(:,:,:,:,:,M_max+2), tree_ID, g_minus=grhs, g_plus=grhs  )
         call RHS_wrapper( time, params, hvy_work(:,:,:,:,:,M_max+2), hvy_work(:,:,:,:,:,M_max+1), &
         hvy_mask, hvy_tmp, tree_ID )
 

--- a/LIB/TIME/krylov.f90
+++ b/LIB/TIME/krylov.f90
@@ -450,7 +450,7 @@ END subroutine DGPADM
 !     h(j+1,j)= h_all
 !     if(h(j+1,j) .eq. 0.0_rk) then
 !         write(*,*)'h(',j+1,j,')  =0.0'
-!         stop
+!         abort(197)
 !     else
 !         v(:,:,:,:,j+1)=v(:,:,:,:,j+1)/h(j+1,j)
 !     end if

--- a/LIB/TIME/runge_kutta_chebychev.f90
+++ b/LIB/TIME/runge_kutta_chebychev.f90
@@ -59,7 +59,7 @@ subroutine RungeKuttaChebychev(time, dt, iteration, params, hvy_block, hvy_work,
     if (s<4) call abort(1715929,"runge-kutta-chebychev: s cannot be less than 4")
 
     ! synchronize ghost nodes
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs  )
+    call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs  )
 
     ! calculate time step
     call calculate_time_step(params, time, iteration, hvy_block, dt, tree_ID)
@@ -91,7 +91,7 @@ subroutine RungeKuttaChebychev(time, dt, iteration, params, hvy_block, hvy_work,
 
         ! F1 = rhs(y1);
         ! note: call sync_ghosts on input data before
-        call sync_ghosts_all( params, lgt_block, hvy_work(:,:,:,:,:,y1), hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs  )
+        call sync_ghosts_tree( params, hvy_work(:,:,:,:,:,y1), tree_ID, g_minus=grhs, g_plus=grhs  )
         call RHS_wrapper( tau, params, hvy_work(:,:,:,:,:,y1), hvy_work(:,:,:,:,:,F1), hvy_mask, hvy_tmp, tree_ID )
 
         ! main formula

--- a/LIB/TIME/runge_kutta_chebychev_FSI.f90
+++ b/LIB/TIME/runge_kutta_chebychev_FSI.f90
@@ -64,7 +64,7 @@ subroutine RungeKuttaChebychev_FSI(time, dt, iteration, params, hvy_block, hvy_w
     endif
 
     ! synchronize ghost nodes
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs  )
+    call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs  )
 
     ! calculate time step
     call calculate_time_step(params, time, iteration, hvy_block, dt, tree_ID)
@@ -103,7 +103,7 @@ subroutine RungeKuttaChebychev_FSI(time, dt, iteration, params, hvy_block, hvy_w
 
         ! F1 = rhs(y1);
         ! note: call sync_ghosts on input data before
-        call sync_ghosts_all( params, lgt_block, hvy_work(:,:,:,:,:,y1), hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs  )
+        call sync_ghosts_tree( params, hvy_work(:,:,:,:,:,y1), tree_ID, g_minus=grhs, g_plus=grhs  )
 
         call RHS_wrapper( tau, params, hvy_work(:,:,:,:,:,y1), hvy_work(:,:,:,:,:,F1), hvy_mask, hvy_tmp, tree_ID )
         ! the rhs wrapper has computed params_acm%force_insect_g and moment_insect_g

--- a/LIB/TIME/runge_kutta_generic.f90
+++ b/LIB/TIME/runge_kutta_generic.f90
@@ -41,7 +41,7 @@ subroutine RungeKuttaGeneric(time, dt, iteration, params, hvy_block, hvy_work, &
     rk_coeffs = params%butcher_tableau
 
     ! synchronize ghost nodes
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs )
+    call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs )
 
     ! calculate time step
     call calculate_time_step(params, time, iteration, hvy_block, dt, tree_ID)
@@ -97,7 +97,7 @@ subroutine RungeKuttaGeneric(time, dt, iteration, params, hvy_block, hvy_work, &
         end do
 
         ! synchronize ghost nodes for new input
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs )
+        call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs )
 
         ! note substeps are at different times, use temporary time "t"
         t = time + dt*rk_coeffs(j,1)

--- a/LIB/TIME/runge_kutta_generic_FSI.f90
+++ b/LIB/TIME/runge_kutta_generic_FSI.f90
@@ -53,7 +53,7 @@ subroutine RungeKuttaGeneric_FSI(time, dt, iteration, params, hvy_block, hvy_wor
     rk_coeffs = params%butcher_tableau
 
     ! synchronize ghost nodes
-    call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs)
+    call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs)
 
     ! calculate time step
     call calculate_time_step(params, time, iteration, hvy_block, dt, tree_ID)
@@ -125,7 +125,7 @@ subroutine RungeKuttaGeneric_FSI(time, dt, iteration, params, hvy_block, hvy_wor
         ! RK substep
         !-----------------------------------------------------------------------
         ! synchronize ghost nodes for new input
-        call sync_ghosts_all( params, lgt_block, hvy_block, hvy_neighbor, hvy_active(:,tree_ID), hvy_n(tree_ID), g_minus=grhs, g_plus=grhs)
+        call sync_ghosts_tree( params, hvy_block, tree_ID, g_minus=grhs, g_plus=grhs)
 
         ! note substeps are at different times, use temporary time "t"
         t = time + dt*rk_coeffs(j,1)

--- a/LIB/TIMING/module_timing.f90
+++ b/LIB/TIMING/module_timing.f90
@@ -56,6 +56,7 @@ contains
     !  120- 124    coarseningIndicator
     !  130- 131    ensureGradedness
     !  140- 146    refine_tree
+    !  150- 158    coarseExtensionUpdate_tree
     !  200-1000 Other
     !  250- 258    forest
     !  350- 354    module_MOR
@@ -204,13 +205,12 @@ contains
     !> \brief Interchange algorithm sorting after one number, copy from quicksort but here to sort out the importing things
     !> \details This algorithm sorts the array a from position first to position last.
     subroutine interchange_sort_timing(a, left_end, right_end)
-        use module_params
         implicit none
-        integer(kind=ik), intent(inout) ::  a(:,:)
-        integer(kind=ik) :: left_end, right_end
+        integer, intent(inout) ::  a(:,:)
+        integer :: left_end, right_end
 
-        integer(kind=ik) :: i, j
-        integer(kind=ik), dimension(size(a, 2)) :: temp
+        integer :: i, j
+        integer, dimension(size(a, 2)) :: temp
 
         do i = left_end, right_end - 1
             do j = i+1, right_end

--- a/LIB/fortran.mk
+++ b/LIB/fortran.mk
@@ -283,7 +283,7 @@ $(OBJDIR)/module_helpers.o: module_helpers.f90 $(OBJDIR)/module_globals.o most_c
 $(OBJDIR)/module_mesh.o: module_mesh.f90 $(OBJDIR)/module_params.o $(OBJDIR)/module_timing.o $(OBJDIR)/module_wavelets.o \
 	$(OBJDIR)/module_mpi.o $(OBJDIR)/module_treelib.o $(OBJDIR)/module_physics_metamodule.o $(OBJDIR)/module_indicators.o \
 	$(OBJDIR)/module_helpers.o $(OBJDIR)/module_params.o $(OBJDIR)/module_forestMetaData.o \
-	unitTest_ghostSync.f90 unitTest_waveletDecomposition.f90 waveletDecomposition_tree.f90 refineToEquidistant_tree.f90 \
+	unitTest_ghostSync.f90 unitTest_waveletDecomposition.f90 refineToEquidistant_tree.f90 \
 	InputOutput_Flusi.f90 InputOutput.f90 create_active_and_sorted_lists.f90 createMask_tree.f90 block_xfer_nonblocking.f90 \
 	updateNeighbors_tree.f90 find_neighbors.f90 doesBlockExist_tree.f90 refine_tree.f90 respectJmaxJmin_tree.f90 \
 	refinementExecute.f90 adapt_tree.f90 coarseningIndicator_tree.f90 ensureGradedness_tree.f90 \

--- a/LIB/fortran.mk
+++ b/LIB/fortran.mk
@@ -329,3 +329,7 @@ $(OBJDIR)/%.o: %.f90 $(MOBJS)
 
 clean-fortran:
 	rm -rf $(PROGRAMS) $(OBJDIR) a.out wabbit wabbit-post
+
+# when running tests in zero there could be traces - make sure they are cleaned
+clean-source:
+	rm -f *.key *.h5 *.t *.dat *.htg *.vtm success

--- a/TESTING/conv/blob_3D_adaptive_CDF22/blob3d-adaptive.sh
+++ b/TESTING/conv/blob_3D_adaptive_CDF22/blob3d-adaptive.sh
@@ -16,7 +16,7 @@ sad=0
 # list of prefixes the test generates
 prefixes=(phi)
 # list of possible times
-times=(000000000000 000000045105)
+times=(000000000000 000000025000)
 
 
 # run actual test

--- a/TESTING/conv/blob_3D_adaptive_CDF22/blob3d.ini
+++ b/TESTING/conv/blob_3D_adaptive_CDF22/blob3d.ini
@@ -102,9 +102,9 @@ u0z=1.0;
 
 [Time]
 ; final time to reach in simulation
-time_max=4.0;
+time_max=0.025;
 ; number of time steps performed. if not set, default value is very large
-nt=10;
+nt=;
 ; CFL criterium
 CFL=1.25;
 ; write method (write with fixed frequency or time ) [ fixed_freq | fixed_time ]

--- a/TESTING/conv/blob_3D_adaptive_CDF22/blob3d.ini
+++ b/TESTING/conv/blob_3D_adaptive_CDF22/blob3d.ini
@@ -104,7 +104,7 @@ u0z=1.0;
 ; final time to reach in simulation
 time_max=4.0;
 ; number of time steps performed. if not set, default value is very large
-nt=16;
+nt=10;
 ; CFL criterium
 CFL=1.25;
 ; write method (write with fixed frequency or time ) [ fixed_freq | fixed_time ]

--- a/TESTING/conv/blob_3D_adaptive_CDF40/blob3d-adaptive.sh
+++ b/TESTING/conv/blob_3D_adaptive_CDF40/blob3d-adaptive.sh
@@ -15,7 +15,7 @@ sad=0
 # list of prefixes the test generates
 prefixes=(phi)
 # list of possible times
-times=(000000000000 000000051549)
+times=(000000000000 000000025000)
 
 # run actual test
 ${mpi_command} ./wabbit ${params} ${memory}

--- a/TESTING/conv/blob_3D_adaptive_CDF40/blob3d.ini
+++ b/TESTING/conv/blob_3D_adaptive_CDF40/blob3d.ini
@@ -102,9 +102,9 @@ u0z=1.0;
 
 [Time]
 ; final time to reach in simulation
-time_max=4.0;
+time_max=0.025;
 ; number of time steps performed. if not set, default value is very large
-nt=10;
+nt=;
 ; CFL criterium
 CFL=1.0;
 ; write method (write with fixed frequency or time ) [ fixed_freq | fixed_time ]

--- a/TESTING/conv/blob_3D_adaptive_CDF40/blob3d.ini
+++ b/TESTING/conv/blob_3D_adaptive_CDF40/blob3d.ini
@@ -104,7 +104,7 @@ u0z=1.0;
 ; final time to reach in simulation
 time_max=4.0;
 ; number of time steps performed. if not set, default value is very large
-nt=20;
+nt=10;
 ; CFL criterium
 CFL=1.0;
 ; write method (write with fixed frequency or time ) [ fixed_freq | fixed_time ]

--- a/TESTING/conv/blob_3D_adaptive_CDF44/blob3d-adaptive.sh
+++ b/TESTING/conv/blob_3D_adaptive_CDF44/blob3d-adaptive.sh
@@ -16,7 +16,7 @@ sad=0
 # list of prefixes the test generates
 prefixes=(phi)
 # list of possible times
-times=(000000000000 000000018042)
+times=(000000000000 000000015000)
 
 
 # run actual test

--- a/TESTING/conv/blob_3D_adaptive_CDF44/blob3d.ini
+++ b/TESTING/conv/blob_3D_adaptive_CDF44/blob3d.ini
@@ -102,9 +102,9 @@ u0z=1.0;
 
 [Time]
 ; final time to reach in simulation
-time_max=4.0;
+time_max=0.015;
 ; number of time steps performed. if not set, default value is very large
-nt=10;
+nt=;
 ; CFL criterium
 CFL=1.00;
 ; write method (write with fixed frequency or time ) [ fixed_freq | fixed_time ]


### PR DESCRIPTION
Hello there

In this commit you can find my change to implement the leaf-based adapt_tree loop.
Main features:
- `adapt_tree` loops not anymore over levels but untreated leaf blocks
- refinement status flags handles if a block is already wavelet decomposed so we do not need to do the heavy work twice
- loop only contains WD and coarsening, afterwards all blocks together perform CE reconstruction or copy only once

I used flags inside the refinement status to know which block is currently an untreated leaf-block and still needs to be wavelet decomposed. This then has to be respected when syncing the ghost nodes resulting in some flags being handed down deep into functions. Please comment anything where you think it needs more explanation - I definitely still have to clean and just wanted to hand it over to you for now.

Tests run as from last merge, they have not been updated yet to match the new security zone so some still fail. I'm interested for the performance and compression test results.