### PR TITLE
Apply reduction before filtering instead of after

### DIFF
--- a/LIB/EQUATION/convection-diffusion/rhs_convdiff.f90
+++ b/LIB/EQUATION/convection-diffusion/rhs_convdiff.f90
@@ -408,8 +408,8 @@ subroutine RHS_convdiff_new(time, g, Bs, dx, x0, phi, rhs, boundary_flag)
         endif
 
         if (phi_max>2000.0_rk) then
-            write(*,*) phi_max
-            call abort(280420232,"large values in phi. that cannot be good.")
+            write(*,'("Phi_max: ", es9.3)') i, phi_max
+            call abort(280420232,"Large values in phi. That cannot be good.")
         endif
     end do
 

--- a/LIB/MAIN/main.f90
+++ b/LIB/MAIN/main.f90
@@ -206,6 +206,8 @@ program main
     ! timing
     call toc( "TOPLEVEL: init_data", 14, MPI_wtime()-sub_t0 )
 
+    ! call abort(197, "Shhhh, Julius is testing!")
+
     !---------------------------------------------------------------------------
     ! main time loop
     !---------------------------------------------------------------------------

--- a/LIB/MESH/adapt_tree.f90
+++ b/LIB/MESH/adapt_tree.f90
@@ -150,7 +150,7 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
         !     endif
         ! enddo
 
-        ! Wavelet-transform all blocks on this level
+        ! Wavelet-transform all remaining non-decomposed blocks
         ! From now on until wavelet retransform hvy_block will hold the wavelet decomposed values in spaghetti form
         t0 = MPI_Wtime()
         do k = 1, hvy_n(tree_ID)
@@ -171,7 +171,8 @@ subroutine adapt_tree( time, params, hvy_block, tree_ID, indicator, hvy_tmp, hvy
                 ! For Jmax if dealiasing, just compute H filter
                 ! Data SC/WC now in Spaghetti order
                 if (level_me == params%Jmax .and. params%force_maxlevel_dealiasing) then
-                    call blockFilterXYZ_vct( params, hvy_block(:,:,:,:,hvy_ID), tmp_wd(:,:,:,:,1), params%HD, lbound(params%HD, dim=1), ubound(params%HD, dim=1))
+                    call blockFilterXYZ_vct( params, hvy_block(:,:,:,:,hvy_ID), tmp_wd(:,:,:,:,1), params%HD, &
+                        lbound(params%HD, dim=1), ubound(params%HD, dim=1), do_restriction=.true.)
                     call inflatedMallat2spaghetti_block(params, tmp_wd, hvy_block(:,:,:,:,hvy_ID), sc_only=.true.)
                 else
                     call waveletDecomposition_block(params, hvy_block(:,:,:,:,hvy_ID))

--- a/LIB/MPI/restrict_predict_data.f90
+++ b/LIB/MPI/restrict_predict_data.f90
@@ -53,7 +53,7 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
     integer(kind=ik), intent(in)    :: num_eqn      !< How many components? Needed as in between we use hvy_tmp
     integer(kind=ik), intent(in)    :: hvy_id
 
-    integer(kind=ik)                :: ix, iy, iz, dF, nc, nx, ny, nz
+    integer(kind=ik)                :: iy, nc, nx, ny, nz
 
     nx = size(hvy_block,1)
     ny = size(hvy_block,2)
@@ -72,11 +72,8 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
     if (hvy_ID /= restricted_hvy_ID) then
         call restrict_copy_at_CE(params, hvy_block, hvy_ID, nc)
 
-        ! call blockFilterXYZ_interior_vct( params, hvy_block(:,:,:,1:nc,hvy_id), hvy_restricted(:,:,:,1:nc), params%HD, &
-        ! lbound(params%HD, dim=1), ubound(params%HD, dim=1), params%g)
-
         ! if (hvy_id == 17 .and. params%rank == 1) THEN
-        !     write(*, '("Restrict block R-0 BH-7 IJK-", 3(i0, "-"), i0)') ijk(:,1:2)
+        !     write(*, '("Restrict block R-1 BH-17 IJK-", 3(i0, "-"), i0)') ijk(:,1:2)
         !     do iy = 2,25, 2
         !         write(*, '(25(es9.2))') hvy_restricted(2:25:2, iy, 1, 1)
         !     enddo
@@ -85,20 +82,11 @@ subroutine restrict_data( params, res_data, ijk, hvy_block, num_eqn, hvy_id )
         restricted_hvy_ID = hvy_ID
     endif
 
-    do dF = 1, nc
-        do iz = ijk(1,3), ijk(2,3), 2
-            do iy = ijk(1,2), ijk(2,2), 2
-                do ix = ijk(1,1), ijk(2,1), 2
+    ! ! apply the filter but only on the patch ijk on which we are interested, as especially for 3D computing it on the whole block is expensive
+    ! call restrict_copy_at_CE(params, hvy_block, hvy_ID, nc, ijk)
 
-                    ! write restricted (downsampled) data
-                    res_data( (ix-ijk(1,1))/2+1, (iy-ijk(1,2))/2+1, (iz-ijk(1,3))/2+1, dF) &
-                    = hvy_restricted( ix, iy, iz, dF)
-                    ! res_data( (ix-ijk(1,1))/2+1, (iy-ijk(1,2))/2+1, (iz-ijk(1,3))/2+1, dF) &
-                    ! = hvy_block( ix, iy, iz, dF, hvy_id )
-                end do
-            end do
-        end do
-    end do
+    res_data( 1:(ijk(2,1)-ijk(1,1))/2+1, 1:(ijk(2,2)-ijk(1,2))/2+1, 1:(ijk(2,3)-ijk(1,3))/2+1, 1:nc) = &
+        hvy_restricted( ijk(1,1):ijk(2,1):2, ijk(1,2):ijk(2,2):2, ijk(1,3):ijk(2,3):2, 1:nc)
 end subroutine restrict_data
 
 
@@ -120,21 +108,37 @@ end subroutine restrict_data
 ! g = ghost point, o = outdated ghost point, i = interior point, f = filtered point, - = value should not be used
 ! Note: The bottom left value is copied (i) due to the finer neighbor in the bottom left corner, the top values due to the coarser top neighbor.
 ! Ghost points of output should not be used, as they may have been filtered correctly, wrongly, partially or left unfiltered arbitrarily
-subroutine restrict_copy_at_CE(params, hvy_data, hvy_ID, num_eqn)
+subroutine restrict_copy_at_CE(params, hvy_data, hvy_ID, num_eqn, ijk)
 
     implicit none
     type (type_params), intent(in) :: params  !< good ol params
     real(kind=rk), intent(inout)   :: hvy_data(:, :, :, :, :)  !< heavy data array - block data
     integer(kind=ik), intent(in)   :: hvy_id  !< which block to look at
     integer(kind=ik), intent(in)   :: num_eqn !< How many components? Needed as it could vary
+    integer(kind=ik), intent(in), optional   :: ijk(2,3)  !< ijk, if this is present we only filter this part
 
     integer(kind=ik) :: k_n, lvl_me, lvl_diff, lgt_ID, lgt_ID_n, HD_l, HD_r
 
     HD_l = lbound(params%HD, dim=1)
     HD_r = ubound(params%HD, dim=1)
 
-    ! filter whole block and don't care about neighbors first
-    call blockFilterXYZ_vct( params, hvy_data(:,:,:,1:num_eqn, hvy_id), hvy_restricted(:,:,:,1:num_eqn), params%HD, HD_l, HD_r)
+    if (.not. present(ijk)) then
+        ! filter whole block and don't care about neighbors first
+        call blockFilterXYZ_vct( params, hvy_data(:,:,:,1:num_eqn, hvy_id), hvy_restricted(:,:,:,1:num_eqn), params%HD, HD_l, HD_r, do_restriction=.true.)
+    else
+        ! only filter parts of the block that we need
+        ! we pass do_restriction=.true. in order to not filter parts we will later restrict
+        if (params%dim == 2) then
+            call blockFilterXYZ_wherepossible_vct( params, &
+                hvy_data(      ijk(1,1)+HD_l:ijk(2,1)+HD_r, ijk(1,2)+HD_l:ijk(2,2)+HD_r, ijk(1,3):ijk(2,3), 1:num_eqn, hvy_id), &
+                hvy_restricted(ijk(1,1)+HD_l:ijk(2,1)+HD_r, ijk(1,2)+HD_l:ijk(2,2)+HD_r, ijk(1,3):ijk(2,3), 1:num_eqn), params%HD, HD_l, HD_r, do_restriction=.true.)
+        else
+            call blockFilterXYZ_wherepossible_vct( params, &
+                hvy_data(      ijk(1,1)+HD_l:ijk(2,1)+HD_r, ijk(1,2)+HD_l:ijk(2,2)+HD_r, ijk(1,3)+HD_l:ijk(2,3)+HD_r, 1:num_eqn, hvy_id), &
+                hvy_restricted(ijk(1,1)+HD_l:ijk(2,1)+HD_r, ijk(1,2)+HD_l:ijk(2,2)+HD_r, ijk(1,3)+HD_l:ijk(2,3)+HD_r, 1:num_eqn), params%HD, HD_l, HD_r, do_restriction=.true.)
+        endif
+        ! call abort(197, "Not finished yet but also how did you end up here?")
+    endif
 
 
     call hvy2lgt(lgt_ID, hvy_ID, params%rank, params%number_blocks)
@@ -147,7 +151,7 @@ subroutine restrict_copy_at_CE(params, hvy_data, hvy_ID, num_eqn)
         if ( lgt_ID_n /= -1 ) then
             lvl_diff = lvl_me - lgt_block(lgt_ID_n, IDX_MESH_LVL)
             if (lvl_diff == -1 .or. lvl_diff == +1) then
-                call coarseExtensionManipulateSC_block(params, hvy_restricted(:,:,:,1:num_eqn), hvy_data(:,:,:,1:num_eqn, hvy_id), k_n, skip_ghosts=.true.)
+                call coarseExtensionManipulateSC_block(params, hvy_restricted(:,:,:,1:num_eqn), hvy_data(:,:,:,1:num_eqn, hvy_id), k_n, skip_ghosts=.true., ijk=ijk)
             endif
         endif
     end do

--- a/LIB/MPI/synchronize_ghosts_generic.f90
+++ b/LIB/MPI/synchronize_ghosts_generic.f90
@@ -180,11 +180,6 @@ subroutine sync_ghosts_generic( params, hvy_block, tree_ID, g_minus, g_plus, &
     if (present(g_minus)) gminus = g_minus
     if (present(g_plus))   gplus = g_plus
 
-#ifdef DEV
-    ! for dev check ghosts by wiping if we set all of them
-    if (sLevel == -1) call reset_ghost_nodes( params, hvy_block, tree_ID, s_M2M=sM2M, s_M2C=sM2C, s_M2F=sM2F)
-#endif
-
     !-----------------------------------------------------------------------
     ! set up constant arrays
     !-----------------------------------------------------------------------
@@ -199,6 +194,11 @@ subroutine sync_ghosts_generic( params, hvy_block, tree_ID, g_minus, g_plus, &
     ! some tiny buffers depend on the number of components (nc=size(hvy_block,4))
     ! make sure they have the right size
     call xfer_ensure_correct_buffer_size(params, hvy_block)
+
+#ifdef DEV
+    ! for dev check ghosts by wiping if we set all of them
+    if (sLevel == -1) call reset_ghost_nodes( params, hvy_block, tree_ID, s_M2M=sM2M, s_M2C=sM2C, s_M2F=sM2F)
+#endif
 
 ! Diagonal neighbors (not required for the RHS)
 ! 2D: 5,6,7,8

--- a/LIB/MPI/synchronize_ghosts_generic.f90
+++ b/LIB/MPI/synchronize_ghosts_generic.f90
@@ -137,7 +137,8 @@ subroutine sync_ghosts_generic( params, hvy_block, tree_ID, g_minus, g_plus, &
 
     integer(kind=ik) :: ijk(2,3), isend, irecv, count_send_total
     integer(kind=ik) :: bounds_type, istage, inverse, gminus, gplus
-    real(kind=rk) :: t0, t1
+    real(kind=rk) :: t0, t1, t2
+    character(len=clong) :: toc_statement
 
     t0 = MPI_wtime()
 
@@ -222,6 +223,7 @@ subroutine sync_ghosts_generic( params, hvy_block, tree_ID, g_minus, g_plus, &
         ! Also applies logic about what should be synched and saves all metadata unsorted in one array
         ! internal nodes are included in metadata but not counted
         t1 = MPI_wtime()
+        t2 = MPI_wtime()  ! stage duration
         call prepare_ghost_synch_metadata(params, tree_ID, count_send_total, &
             istage, ncomponents=size(hvy_block,4), s_Level=sLevel, s_M2M = sM2M, s_M2C = sM2C, s_C2M = sC2M, s_M2F = sM2F, s_F2M = sF2M)
         call toc( "sync ghosts (prepare metadata)", 81, MPI_wtime()-t1 )
@@ -243,6 +245,8 @@ subroutine sync_ghosts_generic( params, hvy_block, tree_ID, g_minus, g_plus, &
             endif
         endif
         call toc( "sync ghosts (xfer_block_data)", 82, MPI_wtime()-t1 )
+        write(toc_statement, '(A, i0, A)') "sync ghosts (stage ", istage, " TOTAL)"
+        call toc( toc_statement, 82+istage, MPI_wtime()-t1 )
 
     end do ! loop over stages 1,2
 

--- a/LIB/TIMING/module_timing.f90
+++ b/LIB/TIMING/module_timing.f90
@@ -30,7 +30,7 @@ module module_timing
     ! each timing slot gets a name and number so it can be easily identified
     ! name is to identify it later by name, they will only be checked for uniqueness for DEV
     ! num is to uniquely address one timing, they should not overlap for different names
-    character(len=100), dimension(:), allocatable :: name_comp_time
+    character(len=120), dimension(:), allocatable :: name_comp_time
     integer, dimension(:, :), allocatable :: num_comp_time
 
 contains
@@ -49,7 +49,7 @@ contains
     !        59    updateMetadata_tree
     !   60-  63    synchronize_lgt_data
     !   70-  74    xfer_block_data
-    !   80-  82    sync ghosts
+    !   80-  85    sync ghosts
     !   90-  92    balanceLoad_tree
     !  100- 200 adapt functions
     !  100- 115    adapt_tree

--- a/LIB/WAVELETS/conversion_routines.f90
+++ b/LIB/WAVELETS/conversion_routines.f90
@@ -1,0 +1,532 @@
+! Inflated Mallat ordering is a HACK. I was just easier to code.
+! That does not mean its wrong, it isn't. But is uses extra memory (although
+! that is negligible) and does unnecessary copy actions.
+subroutine spaghetti2inflatedMallat_block(params, u, wc)
+    implicit none
+    type (type_params), intent(in) :: params
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
+    ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
+    ! Note: the precise naming of SC/WC is not really important. we just apply
+    ! the correct decomposition/reconstruction filters - thats it.
+    !
+    ! INDEX            2D     3D     LABEL
+    ! -----            --    ---     ---------------------------------
+    ! wc(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
+    ! wc(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
+    ! wc(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
+    ! wc(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
+    ! wc(:,:,:,:,5)          HHG     wcz wavelet coeffs
+    ! wc(:,:,:,:,6)          HGG     wcxz wavelet coeffs
+    ! wc(:,:,:,:,7)          GHG     wcyz wavelet coeffs
+    ! wc(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
+    !
+    real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: wc
+    integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
+
+    nx = size(u, 1)
+    ny = size(u, 2)
+    nz = size(u, 3)
+    nc = size(u, 4)
+    g  = params%g
+    Bs = params%bs
+
+#ifdef DEV
+    if (.not.areArraysSameSize(u, wc(:,:,:,:,1))) then
+        call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
+    endif
+#endif
+
+    wc = 0.0_rk
+
+    ! note that what we call "Mallat ordering" here is in fact the "inflated" Mallat
+    ! in the sense that Nx*Ny data gives 4/8 * Nx*Ny decomposition.
+
+    ! copy from Spaghetti to inflated Mallat ordering
+    if (modulo(g, 2) == 0) then
+        ! even g
+        if (params%dim == 2) then
+            wc( 1:nx:2, 1:ny:2, :, :, 1) = u(1:nx:2, 1:ny:2, :, :)
+            wc( 1:nx:2, 1:ny:2, :, :, 2) = u(2:nx:2, 1:ny:2, :, :)
+            wc( 1:nx:2, 1:ny:2, :, :, 3) = u(1:nx:2, 2:ny:2, :, :)
+            wc( 1:nx:2, 1:ny:2, :, :, 4) = u(2:nx:2, 2:ny:2, :, :)
+        else
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 1) = u(1:nx:2, 1:ny:2, 1:nz:2, :)
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 2) = u(2:nx:2, 1:ny:2, 1:nz:2, :)
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 3) = u(1:nx:2, 2:ny:2, 1:nz:2, :)
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 4) = u(2:nx:2, 2:ny:2, 1:nz:2, :)
+
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 5) = u(1:nx:2, 1:ny:2, 2:nz:2, :)
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 6) = u(2:nx:2, 1:ny:2, 2:nz:2, :)
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 7) = u(1:nx:2, 2:ny:2, 2:nz:2, :)
+            wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 8) = u(2:nx:2, 2:ny:2, 2:nz:2, :)
+        endif
+    else
+        ! odd g
+        if (params%dim == 2) then
+            wc( 2:nx-1:2, 2:ny-1:2, :, :, 1) = u(2:nx-1:2, 2:ny-1:2, :, :)
+            wc( 2:nx-1:2, 2:ny-1:2, :, :, 2) = u(3:nx:2  , 2:ny-1:2  , :, :)
+            wc( 2:nx-1:2, 2:ny-1:2, :, :, 3) = u(2:nx-1:2, 3:ny:2  , :, :)
+            wc( 2:nx-1:2, 2:ny-1:2, :, :, 4) = u(3:nx:2  , 3:ny:2    , :, :)
+        else
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 1) = u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :)
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 2) = u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :)
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 3) = u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :)
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 4) = u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :)
+
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 5) = u(2:nx-1:2, 2:ny-1:2, 3:nz:2, :)
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 6) = u(3:nx:2  , 2:ny-1:2, 3:nz:2, :)
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 7) = u(2:nx-1:2, 3:ny:2  , 3:nz:2, :)
+            wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 8) = u(3:nx:2  , 3:ny:2  , 3:nz:2, :)
+        endif
+    endif
+end subroutine
+
+
+! Inflated Mallat ordering is a HACK. I was just easier to code.
+! That does not mean its wrong, it isn't. But is uses extra memory (although
+! that is negligible) and does unnecessary copy actions.
+subroutine inflatedMallat2spaghetti_block(params, wc, u, sc_only)
+    implicit none
+    type (type_params), intent(in) :: params
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
+    ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
+    ! Note: the precise naming of SC/WC is not really important. we just apply
+    ! the correct decomposition/reconstruction filters - thats it.
+    !
+    ! INDEX            2D     3D     LABEL
+    ! -----            --    ---     ---------------------------------
+    ! wc(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
+    ! wc(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
+    ! wc(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
+    ! wc(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
+    ! wc(:,:,:,:,5)          HHG     wcz wavelet coeffs
+    ! wc(:,:,:,:,6)          HGG     wcxz wavelet coeffs
+    ! wc(:,:,:,:,7)          GHG     wcyz wavelet coeffs
+    ! wc(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
+    !
+    real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: wc
+    !> Option to only convert SC
+    logical, optional, intent(in)  :: sc_only
+
+    integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3), i_s, i_e
+    logical sc_only_set
+
+    sc_only_set = .false.
+    if (present(sc_only)) sc_only_set = sc_only
+
+    nx = size(u, 1)
+    ny = size(u, 2)
+    nz = size(u, 3)
+    nc = size(u, 4)
+    g  = params%g
+    Bs = params%bs
+
+#ifdef DEV
+    if (.not.areArraysSameSize(u, wc(:,:,:,:,1))) then
+        call abort(27222119, "Allocated arrays are not compatible?! Time for a drink. You look handsome today.")
+    endif
+#endif
+
+    ! note that what we call "Mallat ordering" here is in fact the "inflated" Mallat
+    ! in the sense that Nx*Ny data gives 4/8 * Nx*Ny decomposition.
+
+    ! compute index shift for odd g, ignoring outmost elements
+    i_s = 1 + modulo(g, 2)  ! 1 for even, 2 for odd
+    i_e = 0 + modulo(g, 2)  ! 0 for even, 1 for odd
+
+    ! copy from inflated Mallat to Mallat ordering
+    if (params%dim == 2) then
+        u(       i_s:nx-i_e:2,   i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 1)
+        if (.not. sc_only_set) then
+            u( 1+i_s:nx-i_e:2,   i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 2)
+            u(   i_s:nx-i_e:2, 1+i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 3)
+            u( 1+i_s:nx-i_e:2, 1+i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 4)
+        endif
+    else
+        u(       i_s:nx-i_e:2,   i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 1)
+        if (.not. sc_only_set) then
+            u( 1+i_s:nx-i_e:2,   i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 2)
+            u(   i_s:nx-i_e:2, 1+i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 3)
+            u( 1+i_s:nx-i_e:2, 1+i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 4)
+
+            u(   i_s:nx-i_e:2,   i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 5)
+            u( 1+i_s:nx-i_e:2,   i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 6)
+            u(   i_s:nx-i_e:2, 1+i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 7)
+            u( 1+i_s:nx-i_e:2, 1+i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 8)
+        endif
+    endif
+
+    ! ! copy from inflated Mallat to Spaghetti ordering
+    ! if (modulo(g, 2) == 0) then
+    !     ! even g
+    !     if (params%dim == 2) then
+    !         u(1:nx:2, 1:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 1)
+    !         u(2:nx:2, 1:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 2)
+    !         u(1:nx:2, 2:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 3)
+    !         u(2:nx:2, 2:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 4)
+    !     else
+    !         u(1:nx:2, 1:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 1)
+    !         u(2:nx:2, 1:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 2)
+    !         u(1:nx:2, 2:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 3)
+    !         u(2:nx:2, 2:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 4)
+
+    !         u(1:nx:2, 1:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 5)
+    !         u(2:nx:2, 1:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 6)
+    !         u(1:nx:2, 2:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 7)
+    !         u(2:nx:2, 2:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 8)
+    !     endif
+    ! else
+    !     ! odd g
+    !     if (params%dim == 2) then
+    !         u(2:nx-1:2, 2:ny-1:2, :, :) = wc( 2:nx-1:2, 2:ny-1:2, :, :, 1)
+    !         u(3:nx:2  , 2:ny-1:2, :, :) = wc( 2:nx-1:2, 2:ny-1:2, :, :, 2)
+    !         u(2:nx-1:2, 3:ny:2, :, :)   = wc( 2:nx-1:2, 2:ny-1:2, :, :, 3)
+    !         u(3:nx:2  , 3:ny:2, :, :)   = wc( 2:nx-1:2, 2:ny-1:2, :, :, 4)
+    !     else
+    !         u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 1)
+    !         u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 2)
+    !         u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 3)
+    !         u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 4)
+
+    !         u(2:nx-1:2, 2:ny-1:2, 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 5)
+    !         u(3:nx:2  , 2:ny-1:2, 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 6)
+    !         u(2:nx-1:2, 3:ny:2  , 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 7)
+    !         u(3:nx:2  , 3:ny:2  , 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 8)
+    !     endif
+    ! endif
+
+end subroutine
+
+
+subroutine spaghetti2Mallat_block(params, u, wc)
+    implicit none
+    type (type_params), intent(in) :: params
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
+    ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
+    ! Note: the precise naming of SC/WC is not really important. we just apply
+    ! the correct decomposition/reconstruction filters - thats it.
+    !
+    ! INDEX                                        2D     3D     LABEL
+    ! -----------------------------------------    --    ---     ---------------------------------
+    ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
+    ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
+    !
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
+    integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
+
+    nx = size(u, 1)
+    ny = size(u, 2)
+    nz = size(u, 3)
+    nc = size(u, 4)
+    g  = params%g
+    Bs = params%bs
+
+#ifdef DEV
+    if (.not.areArraysSameSize(u, wc)) then
+        call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
+    endif
+#endif
+
+    wc = 0.0_rk
+
+    ! copy from Spaghetti to Mallat ordering
+    if (modulo(g, 2) == 0) then
+        ! even g
+        if (params%dim == 2) then
+            wc(      1:nx/2,      1:ny/2, :, :) = u(1:nx:2, 1:ny:2, :, :)
+            wc(      1:nx/2, ny/2+1:ny  , :, :) = u(2:nx:2, 1:ny:2, :, :)
+            wc( nx/2+1:nx  ,      1:ny/2, :, :) = u(1:nx:2, 2:ny:2, :, :)
+            wc( nx/2+1:nx  , ny/2+1:ny  , :, :) = u(2:nx:2, 2:ny:2, :, :)
+        else
+            wc(      1:nx/2,      1:ny/2,      1:nz/2, :) = u(1:nx:2, 1:ny:2, 1:nz:2, :)
+            wc(      1:nx/2, ny/2+1:ny  ,      1:nz/2, :) = u(2:nx:2, 1:ny:2, 1:nz:2, :)
+            wc( nx/2+1:nx  ,      1:ny/2,      1:nz/2, :) = u(1:nx:2, 2:ny:2, 1:nz:2, :)
+            wc( nx/2+1:nx  , ny/2+1:ny  ,      1:nz/2, :) = u(2:nx:2, 2:ny:2, 1:nz:2, :)
+
+            wc(      1:nx/2,      1:ny/2, nz/2+1:nz  , :) = u(1:nx:2, 1:ny:2, 2:nz:2, :)
+            wc(      1:nx/2, ny/2+1:ny  , nz/2+1:nz  , :) = u(2:nx:2, 1:ny:2, 2:nz:2, :)
+            wc( nx/2+1:nx  ,      1:ny/2, nz/2+1:nz  , :) = u(1:nx:2, 2:ny:2, 2:nz:2, :)
+            wc( nx/2+1:nx  , ny/2+1:ny  , nz/2+1:nz  , :) = u(2:nx:2, 2:ny:2, 2:nz:2, :)
+        endif
+    else
+        ! odd g
+        if (params%dim == 2) then
+            wc(      2:nx/2,      2:ny/2, :, :) = u(2:nx-1:2, 2:ny-1:2, :, :)
+            wc(      2:nx/2, ny/2+1:ny-1, :, :) = u(3:nx:2  , 2:ny-1:2, :, :)
+            wc( nx/2+1:nx-1,      2:ny/2, :, :) = u(2:nx-1:2, 3:ny:2  , :, :)
+            wc( nx/2+1:nx-1, ny/2+1:ny-1, :, :) = u(3:nx:2  , 3:ny:2  , :, :)
+        else
+            wc(      2:nx/2,      2:ny/2,      2:nz/2, :) = u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :)
+            wc(      2:nx/2, ny/2+1:ny-1,      2:nz/2, :) = u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :)
+            wc( nx/2+1:nx-1,      2:ny/2,      2:nz/2, :) = u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :)
+            wc( nx/2+1:nx-1, ny/2+1:ny-1,      2:nz/2, :) = u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :)
+
+            wc(      2:nx/2,      2:ny/2, nz/2+1:nz-1, :) = u(2:nx-1:2, 2:ny-1:2, 3:nz:2  , :)
+            wc(      2:nx/2, ny/2+1:ny-1, nz/2+1:nz-1, :) = u(3:nx:2  , 2:ny-1:2, 3:nz:2  , :)
+            wc( nx/2+1:nx-1,      2:ny/2, nz/2+1:nz-1, :) = u(2:nx-1:2, 3:ny:2  , 3:nz:2  , :)
+            wc( nx/2+1:nx-1, ny/2+1:ny-1, nz/2+1:nz-1, :) = u(3:nx:2  , 3:ny:2  , 3:nz:2  , :)
+        endif
+    endif
+end subroutine
+
+
+
+subroutine Mallat2Spaghetti_block(params, wc, u)
+    implicit none
+    type (type_params), intent(in) :: params
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
+    ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
+    ! Note: the precise naming of SC/WC is not really important. we just apply
+    ! the correct decomposition/reconstruction filters - thats it.
+    !
+    ! INDEX                                        2D     3D     LABEL
+    ! -----------------------------------------    --    ---     ---------------------------------
+    ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
+    ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
+    !
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
+    integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
+
+    nx = size(u, 1)
+    ny = size(u, 2)
+    nz = size(u, 3)
+    nc = size(u, 4)
+    g  = params%g
+    Bs = params%bs
+
+#ifdef DEV
+    if (.not.areArraysSameSize(u, wc)) then
+        call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
+    endif
+#endif
+
+    u = 0.0_rk
+
+    ! copy from Mallat to Spaghetti ordering
+    if (modulo(g, 2) == 0) then
+        ! even g
+        if (params%dim == 2) then
+            u(1:nx:2, 1:ny:2, :, :) = wc(      1:nx/2,      1:ny/2, :, :)
+            u(2:nx:2, 1:ny:2, :, :) = wc(      1:nx/2, ny/2+1:ny  , :, :)
+            u(1:nx:2, 2:ny:2, :, :) = wc( nx/2+1:nx  ,      1:ny/2, :, :)
+            u(2:nx:2, 2:ny:2, :, :) = wc( nx/2+1:nx  , ny/2+1:ny  , :, :)
+        else
+            u(1:nx:2, 1:ny:2, 1:nz:2, :) = wc(      1:nx/2,      1:ny/2,      1:nz/2, :)
+            u(2:nx:2, 1:ny:2, 1:nz:2, :) = wc(      1:nx/2, ny/2+1:ny  ,      1:nz/2, :)
+            u(1:nx:2, 2:ny:2, 1:nz:2, :) = wc( nx/2+1:nx  ,      1:ny/2,      1:nz/2, :)
+            u(2:nx:2, 2:ny:2, 1:nz:2, :) = wc( nx/2+1:nx  , ny/2+1:ny  ,      1:nz/2, :)
+
+            u(1:nx:2, 1:ny:2, 2:nz:2, :) = wc(      1:nx/2,      1:ny/2, nz/2+1:nz  , :)
+            u(2:nx:2, 1:ny:2, 2:nz:2, :) = wc(      1:nx/2, ny/2+1:ny  , nz/2+1:nz  , :)
+            u(1:nx:2, 2:ny:2, 2:nz:2, :) = wc( nx/2+1:nx  ,      1:ny/2, nz/2+1:nz  , :)
+            u(2:nx:2, 2:ny:2, 2:nz:2, :) = wc( nx/2+1:nx  , ny/2+1:ny  , nz/2+1:nz  , :)
+        endif
+    else
+        ! odd g
+        if (params%dim == 2) then
+            u(2:nx-1:2, 2:ny-1:2, :, :) = wc(      2:nx/2,      2:ny/2, :, :)
+            u(3:nx:2  , 2:ny-1:2, :, :) = wc(      2:nx/2, ny/2+1:ny-1, :, :)
+            u(2:nx-1:2, 3:ny:2  , :, :) = wc( nx/2+1:nx-1,      2:ny/2, :, :)
+            u(3:nx:2  , 3:ny:2  , :, :) = wc( nx/2+1:nx-1, ny/2+1:ny-1, :, :)
+        else
+            u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :) = wc(      2:nx/2,      2:ny/2,      2:nz/2, :)
+            u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :) = wc(      2:nx/2, ny/2+1:ny-1,      2:nz/2, :)
+            u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :) = wc( nx/2+1:nx-1,      2:ny/2,      2:nz/2, :)
+            u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :) = wc( nx/2+1:nx-1, ny/2+1:ny-1,      2:nz/2, :)
+
+            u(2:nx-1:2, 2:ny-1:2, 3:nz:2  , :) = wc(      2:nx/2,      2:ny/2, nz/2+1:nz-1, :)
+            u(3:nx:2  , 2:ny-1:2, 3:nz:2  , :) = wc(      2:nx/2, ny/2+1:ny-1, nz/2+1:nz-1, :)
+            u(2:nx-1:2, 3:ny:2  , 3:nz:2  , :) = wc( nx/2+1:nx-1,      2:ny/2, nz/2+1:nz-1, :)
+            u(3:nx:2  , 3:ny:2  , 3:nz:2  , :) = wc( nx/2+1:nx-1, ny/2+1:ny-1, nz/2+1:nz-1, :)
+        endif
+    endif
+end subroutine
+
+
+
+! Inflated Mallat ordering is a HACK. I was just easier to code.
+! That does not mean its wrong, it isn't. But is uses extra memory (although
+! that is negligible) and does unnecessary copy actions.
+subroutine Mallat2inflatedMallat_block(params, wc, u)
+    implicit none
+    type (type_params), intent(in) :: params
+    ! The WC and u array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
+    ! Note: the precise naming of SC/WC is not really important. we just apply
+    ! the correct decomposition/reconstruction filters - thats it.
+    !
+    ! INDEX                                        2D     3D     LABEL
+    ! -----------------------------------------    --    ---     ---------------------------------
+    ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
+    ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
+    ! INDEX            2D     3D     LABEL
+    ! -----            --    ---     ---------------------------------
+    ! u(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
+    ! u(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
+    ! u(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
+    ! u(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
+    ! u(:,:,:,:,5)          HHG     wcz wavelet coeffs
+    ! u(:,:,:,:,6)          HGG     wcxz wavelet coeffs
+    ! u(:,:,:,:,7)          GHG     wcyz wavelet coeffs
+    ! u(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
+    real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: u
+
+    integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
+
+    nx = size(u, 1)
+    ny = size(u, 2)
+    nz = size(u, 3)
+    nc = size(u, 4)
+    g  = params%g
+    Bs = params%bs
+
+#ifdef DEV
+    if (.not.areArraysSameSize(wc, u(:,:,:,:,1))) then
+        call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
+    endif
+#endif
+
+    u = 0.0_rk
+
+    ! copy from Mallat to inflated Mallat ordering
+    if (modulo(g, 2) == 0) then
+        ! even g
+        if (params%dim == 2) then
+            u( 1:nx:2, 1:ny:2, :, :, 1) = wc(      1:nx/2,      1:ny/2, :, :)
+            u( 1:nx:2, 1:ny:2, :, :, 2) = wc(      1:nx/2, ny/2+1:ny  , :, :)
+            u( 1:nx:2, 1:ny:2, :, :, 3) = wc( nx/2+1:nx  ,      1:ny/2, :, :)
+            u( 1:nx:2, 1:ny:2, :, :, 4) = wc( nx/2+1:nx  , ny/2+1:ny  , :, :)
+        else
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 1) = wc(      1:nx/2,      1:ny/2,      1:nz/2, :)
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 2) = wc(      1:nx/2, ny/2+1:ny  ,      1:nz/2, :)
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 3) = wc( nx/2+1:nx  ,      1:ny/2,      1:nz/2, :)
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 4) = wc( nx/2+1:nx  , ny/2+1:ny  ,      1:nz/2, :)
+
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 5) = wc(      1:nx/2,      1:ny/2, nz/2+1:nz  , :)
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 6) = wc(      1:nx/2, ny/2+1:ny  , nz/2+1:nz  , :)
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 7) = wc( nx/2+1:nx  ,      1:ny/2, nz/2+1:nz  , :)
+            u( 1:nx:2, 1:ny:2, 1:nz:2, :, 8) = wc( nx/2+1:nx  , ny/2+1:ny  , nz/2+1:nz  , :)
+        endif
+    else
+        ! odd g
+        if (params%dim == 2) then
+            u( 2:nx-1:2, 2:ny-1:2, :, :, 1) = wc(      2:nx/2,      2:ny/2, :, :)
+            u( 2:nx-1:2, 2:ny-1:2, :, :, 2) = wc(      2:nx/2, ny/2+1:ny-1, :, :)
+            u( 2:nx-1:2, 2:ny-1:2, :, :, 3) = wc( nx/2+1:nx-1,      2:ny/2, :, :)
+            u( 2:nx-1:2, 2:ny-1:2, :, :, 4) = wc( nx/2+1:nx-1, ny/2+1:ny-1, :, :)
+        else
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 1) = wc(      2:nx/2,      2:ny/2,      2:nz/2, :)
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 2) = wc(      2:nx/2, ny/2+1:ny-1,      2:nz/2, :)
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 3) = wc( nx/2+1:nx-1,      2:ny/2,      2:nz/2, :)
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 4) = wc( nx/2+1:nx-1, ny/2+1:ny-1,      2:nz/2, :)
+
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 5) = wc(      2:nx/2,      2:ny/2, nz/2+1:nz-1, :)
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 6) = wc(      2:nx/2, ny/2+1:ny-1, nz/2+1:nz-1, :)
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 7) = wc( nx/2+1:nx-1,      2:ny/2, nz/2+1:nz-1, :)
+            u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 8) = wc( nx/2+1:nx-1, ny/2+1:ny-1, nz/2+1:nz-1, :)
+        endif
+    endif
+end subroutine
+
+
+
+! Inflated Mallat ordering is a HACK. I was just easier to code.
+! That does not mean its wrong, it isn't. But is uses extra memory (although
+! that is negligible) and does unnecessary copy actions.
+subroutine inflatedMallat2Mallat_block(params, u, wc, sc_only)
+    implicit none
+    type (type_params), intent(in) :: params
+    ! The WC and u array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
+    ! Note: the precise naming of SC/WC is not really important. we just apply
+    ! the correct decomposition/reconstruction filters - thats it.
+    !
+    ! INDEX                                        2D     3D     LABEL
+    ! -----------------------------------------    --    ---     ---------------------------------
+    ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
+    ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
+    ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
+    ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
+    ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
+    real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
+    ! INDEX            2D     3D     LABEL
+    ! -----            --    ---     ---------------------------------
+    ! u(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
+    ! u(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
+    ! u(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
+    ! u(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
+    ! u(:,:,:,:,5)          HHG     wcz wavelet coeffs
+    ! u(:,:,:,:,6)          HGG     wcxz wavelet coeffs
+    ! u(:,:,:,:,7)          GHG     wcyz wavelet coeffs
+    ! u(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
+    real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: u
+    !> Option to only convert SC
+    logical, optional, intent(in)  :: sc_only
+
+    integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3), i_s, i_e
+    logical sc_only_set
+
+    sc_only_set = .false.
+    if (present(sc_only)) sc_only_set = sc_only
+
+    nx = size(u, 1)
+    ny = size(u, 2)
+    nz = size(u, 3)
+    nc = size(u, 4)
+    g  = params%g
+    Bs = params%bs
+
+#ifdef DEV
+    if (.not.areArraysSameSize(wc, u(:,:,:,:,1))) then
+        call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
+    endif
+#endif
+
+    wc = 0.0_rk
+
+    ! compute index shift for odd g, ignoring outmost elements
+    i_s = 1 + modulo(g, 2)  ! 1 for even, 2 for odd
+    i_e = 0 + modulo(g, 2)  ! 0 for even, 1 for odd
+
+    ! copy from inflated Mallat to Mallat ordering
+    if (params%dim == 2) then
+        wc(        i_s:nx/2  ,    i_s:ny/2  , :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 1)
+        if (.not. sc_only_set) then
+            wc(    i_s:nx/2  , ny/2+1:ny-i_e, :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 2)
+            wc( nx/2+1:nx-i_e,    i_s:ny/2  , :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 3)
+            wc( nx/2+1:nx-i_e, ny/2+1:ny-i_e, :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 4)
+        endif
+    else
+        wc(        i_s:nx/2  ,    i_s:ny/2  ,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 1)
+        if (.not. sc_only_set) then
+            wc(    i_s:nx/2  , ny/2+1:ny-i_e,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 2)
+            wc( nx/2+1:nx-i_e,    i_s:ny/2  ,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 3)
+            wc( nx/2+1:nx-i_e, ny/2+1:ny-i_e,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 4)
+    
+            wc(    i_s:nx/2  ,    i_s:ny/2  , nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 5)
+            wc(    i_s:nx/2  , ny/2+1:ny-i_e, nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 6)
+            wc( nx/2+1:nx-i_e,    i_s:ny/2  , nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 7)
+            wc( nx/2+1:nx-i_e, ny/2+1:ny-i_e, nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 8)
+        endif
+    endif
+end subroutine

--- a/LIB/WAVELETS/module_wavelets.f90
+++ b/LIB/WAVELETS/module_wavelets.f90
@@ -5,6 +5,8 @@ module module_wavelets
 
 contains
 
+#include "conversion_routines.f90"
+
     ! coarsen the block by one level
     subroutine restriction_2D(fine, coarse)
         implicit none
@@ -29,16 +31,17 @@ contains
 
     end subroutine
 
-    subroutine restriction_prefilter(params, u, u_filtered)
-        implicit none
-        type(type_params), intent(in) :: params
-        real(kind=rk), dimension(1:,1:,1:), intent(in) :: u
-        real(kind=rk), dimension(1:,1:,1:), intent(out) :: u_filtered
+    ! ! Version without vectors
+    ! subroutine restriction_prefilter(params, u, u_filtered)
+    !     implicit none
+    !     type(type_params), intent(in) :: params
+    !     real(kind=rk), dimension(1:,1:,1:), intent(in) :: u
+    !     real(kind=rk), dimension(1:,1:,1:), intent(out) :: u_filtered
 
-        if (.not. allocated(params%HD)) call abort(71717172, "wavelet not setup")
+    !     if (.not. allocated(params%HD)) call abort(71717172, "wavelet not setup")
 
-        call blockFilterXYZ(params, u, u_filtered, params%HD, lbound(params%HD, dim=1), ubound(params%HD, dim=1))
-    end subroutine
+    !     call blockFilterXYZ(params, u, u_filtered, params%HD, lbound(params%HD, dim=1), ubound(params%HD, dim=1))
+    ! end subroutine
 
 
     subroutine restriction_prefilter_vct(params, u, u_filtered)
@@ -318,97 +321,108 @@ contains
     end subroutine
 
 
-    ! Please note applying a filter requires also manipulating the ghost nodes
-    subroutine blockFilterXYZ( params, u, u_filtered, coefs_filter, a, b )
-        implicit none
-        type (type_params), intent(in) :: params
-        real(kind=rk), dimension(1:,1:,1:), intent(in) :: u
-        real(kind=rk), dimension(1:,1:,1:), intent(inout) :: u_filtered
-        integer(kind=ik) :: a, b
-        real(kind=rk), intent(in) :: coefs_filter(a:b)
-        integer(kind=ik) :: ix, iy, iz, nx, ny, nz, shift, g, Bs(1:3)
-        real(kind=rk), allocatable, save :: u_tmp(:,:,:)
+    ! ! Please note applying a filter requires also manipulating the ghost nodes
+    ! ! Version without vectors
+    ! subroutine blockFilterXYZ( params, u, u_filtered, coefs_filter, a, b )
+    !     implicit none
+    !     type (type_params), intent(in) :: params
+    !     real(kind=rk), dimension(1:,1:,1:), intent(in) :: u
+    !     real(kind=rk), dimension(1:,1:,1:), intent(inout) :: u_filtered
+    !     integer(kind=ik) :: a, b
+    !     real(kind=rk), intent(in) :: coefs_filter(a:b)
+    !     integer(kind=ik) :: ix, iy, iz, nx, ny, nz, shift, g, Bs(1:3)
+    !     real(kind=rk), allocatable, save :: u_tmp(:,:,:)
 
-        ! if the filter is just 1, then we copy and we're done.
-        ! Yes, we use such stupid filters. They are in the CDFX0 wavelets (X=2,4)
-        if (a==0 .and. b==0 .and. abs(coefs_filter(0)-1.0_rk)<=1.0e-10_rk) then
-            u_filtered = u
-            return
-        endif
+    !     ! if the filter is just 1, then we copy and we're done.
+    !     ! Yes, we use such stupid filters. They are in the CDFX0 wavelets (X=2,4)
+    !     if (a==0 .and. b==0 .and. abs(coefs_filter(0)-1.0_rk)<=1.0e-10_rk) then
+    !         u_filtered = u
+    !         return
+    !     endif
 
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        g  = params%g
-        Bs = params%Bs
+    !     nx = size(u, 1)
+    !     ny = size(u, 2)
+    !     nz = size(u, 3)
+    !     g  = params%g
+    !     Bs = params%Bs
 
-        if ((abs(a) > g).or.(b>g)) then
-            write(*,*) a, b, "but g=", g
-            call abort(202302209, "For applying the filter, not enough ghost nodes")
-        endif
+    !     if ((abs(a) > g).or.(b>g)) then
+    !         write(*,*) a, b, "but g=", g
+    !         call abort(202302209, "For applying the filter, not enough ghost nodes")
+    !     endif
 
-        if (.not. allocated(u_tmp)) allocate( u_tmp(1:nx,1:ny,1:nz) )
-        u_tmp = u
+    !     if (.not. allocated(u_tmp)) allocate( u_tmp(1:nx,1:ny,1:nz) )
+    !     u_tmp = u
 
-        u_filtered = u_tmp
-        u_filtered(g+1:Bs(1)+g, :, :) = 0.0_rk
-        do ix = g+1, Bs(1)+g
-            ! do ix = -a+1, nx-b
-            do shift = a, b
-                u_filtered(ix, :, :) = u_filtered(ix, :, :) + u_tmp(ix+shift, :, :)*coefs_filter(shift)
-            enddo
-        enddo
+    !     u_filtered = u_tmp
+    !     u_filtered(g+1:Bs(1)+g, :, :) = 0.0_rk
+    !     do ix = g+1, Bs(1)+g
+    !         ! do ix = -a+1, nx-b
+    !         do shift = a, b
+    !             u_filtered(ix, :, :) = u_filtered(ix, :, :) + u_tmp(ix+shift, :, :)*coefs_filter(shift)
+    !         enddo
+    !     enddo
 
-        u_tmp = u_filtered
-        u_filtered = u_tmp
-        u_filtered(:, g+1:Bs(2)+g, :) = 0.0_rk
-        do iy = g+1, Bs(2)+g
-            ! do iy = -a+1, ny-b
-            do shift = a, b
-                u_filtered(:, iy, :) = u_filtered(:, iy, :) + u_tmp(:, iy+shift, :)*coefs_filter(shift)
-            enddo
-        enddo
+    !     u_tmp = u_filtered
+    !     u_filtered = u_tmp
+    !     u_filtered(:, g+1:Bs(2)+g, :) = 0.0_rk
+    !     do iy = g+1, Bs(2)+g
+    !         ! do iy = -a+1, ny-b
+    !         do shift = a, b
+    !             u_filtered(:, iy, :) = u_filtered(:, iy, :) + u_tmp(:, iy+shift, :)*coefs_filter(shift)
+    !         enddo
+    !     enddo
 
-        if (nz == 1) return
+    !     if (nz == 1) return
 
-        u_tmp = u_filtered
-        u_filtered = u_tmp
-        u_filtered(:, :, g+1:Bs(3)+g) = 0.0_rk
-        do iz = g+1, Bs(3)+g
-            do shift = a, b
-                u_filtered(:, :, iz) = u_filtered(:, :, iz) + u_tmp(:, :, iz+shift)*coefs_filter(shift)
-            enddo
-        enddo
+    !     u_tmp = u_filtered
+    !     u_filtered = u_tmp
+    !     u_filtered(:, :, g+1:Bs(3)+g) = 0.0_rk
+    !     do iz = g+1, Bs(3)+g
+    !         do shift = a, b
+    !             u_filtered(:, :, iz) = u_filtered(:, :, iz) + u_tmp(:, :, iz+shift)*coefs_filter(shift)
+    !         enddo
+    !     enddo
 
-    end subroutine
+    ! end subroutine
 
 
     ! Filters a block, all internal nodes, assuming g >= support of filter (crashes otherwise)
-    !
-    ! g g g g g g g g g g g          g g g g g g g g g g g
-    ! g g g g g g g g g g g          g g g g g g g g g g g
-    ! g g i i i i i i i g g          g g f f f f f f f g g
-    ! g g i i i i i i i g g          g g f f f f f f f g g
-    ! g g i i i i i i i g g          g g f f f f f f f g g
-    ! g g i i i i i i i g g          g g f f f f f f f g g
-    ! g g i i i i i i i g g          g g f f f f f f f g g
-    ! g g i i i i i i i g g          g g f f f f f f f g g
-    ! g g g g g g g g g g g          g g g g g g g g g g g
-    ! g g g g g g g g g g g          g g g g g g g g g g g
-    ! Fig1: g= ghost i=internal      Fig2: f=filtered
-    subroutine blockFilterXYZ_vct( params, u, u_filtered, coefs_filter, a, b)
+    ! Bs=6, g=2, HD=[-1:1]
+    ! g g g g g g g g g g          g g g g g g g g g g          g g g g g g g g g g
+    ! g g g g g g g g g g          g g p p p p p p g g          g g p g p g g g g g
+    ! g g i i i i i i g g          g g f f f f f f g g          g g p i p i p i g g
+    ! g g i i i i i i g g          g g f f f f f f g g          g g f i f i f i g g
+    ! g g i i i i i i g g          g g f f f f f f g g          g g p i p i p i g g
+    ! g g i i i i i i g g          g g f f f f f f g g          g g f i f i f i g g
+    ! g g i i i i i i g g          g g f f f f f f g g          g g p i p i p i g g
+    ! g g i i i i i i g g          g g f f f f f f g g          g g f i f i f i g g
+    ! g g g g g g g g g g          g g p p p p p p g g          g g p g p g g g g g
+    ! g g g g g g g g g g          g g g g g g g g g g          g g g g g g g g g g
+    ! Fig1: input                    Fig2: out filtered           Fig3: filtered with restriction
+    ! g=ghost i=internal f=filtered p=partially filtered
+    ! For filtered: After the first dimension filtering we can ignore the edge-values (left and right side), this might not seem much for a full block
+    !       but for ghost patches we sometimes have very small patches with large support.
+    !       Additionally, if filter < g then some values at the edges need not be touched (top and bottom row)
+    ! For filtered with restriction: Every dimension we only filter the restricted points (so NOT every second and at ghost point where filter)
+    !       Afterwards, the next filtering considers for this dimension only those values so we have computing costs of (1/2 + 1/4 + 1/8) / 3 instead of 1
+    ! As edges can be partially filtered or not they should not be used!
+    subroutine blockFilterXYZ_vct( params, u, u_filtered, coefs_filter, fl_l, fl_r, do_restriction)
         implicit none
         type (type_params), intent(in) :: params
         real(kind=rk), dimension(1:,1:,1:,1:), intent(in) :: u
         real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u_filtered
-        integer(kind=ik) :: a, b
-        real(kind=rk), intent(in) :: coefs_filter(a:b)
+        integer(kind=ik), intent(in) :: fl_l, fl_r  !< Filter length left and right
+        real(kind=rk), intent(in) :: coefs_filter(fl_l:fl_r)
+        logical, intent(in), optional :: do_restriction  !< when we do restriction anyways we can skip every second point
+
         integer(kind=ik) :: ix, iy, iz, nx, ny, nz, nc, shift, g, Bs(1:3)
         real(kind=rk), allocatable, save :: u_tmp(:,:,:,:)
+        integer(kind=ik) :: s  ! sample_num, is either 1 or 2
 
         ! if the filter is just 1, then we copy and we're done.
         ! Yes, we use such stupid filters. They are in the CDFX0 wavelets (X=2,4)
-        if (a==0 .and. b==0 .and. abs(coefs_filter(0)-1.0_rk)<=1.0e-10_rk) then
+        if (fl_l==0 .and. fl_r==0 .and. abs(coefs_filter(0)-1.0_rk)<=1.0e-10_rk) then
             u_filtered = u
             return
         endif
@@ -421,40 +435,72 @@ contains
         g  = params%g
         Bs = params%Bs
 
-        if ((abs(a) > g).or.(b>g)) then
-            write(*,*) a, b, "but g=", g
+        if ((abs(fl_l) > g).or.(fl_r>g)) then
+            write(*,*) fl_l, fl_r, "but g=", g
             call abort(202302209, "For applying the filter, not enough ghost nodes")
+        endif
+
+        s = 1
+        if (present(do_restriction)) then
+            if (do_restriction) s = 2
         endif
 
         if (.not. allocated(u_tmp)) allocate( u_tmp(1:nx,1:ny,1:nz,1:nc) )
         u_tmp = u
 
         u_filtered = u_tmp
-        u_filtered(g+1:Bs(1)+g, :, :, :) = 0.0_rk
-        do ix = g+1, Bs(1)+g
-            do shift = a, b
-                u_filtered(ix, :, :, :) = u_filtered(ix, :, :, :) + u_tmp(ix+shift, :, :, :)*coefs_filter(shift)
+        if (nz == 1) then
+            u_filtered(g+1:Bs(1)+g:s, g+1+fl_l:Bs(2)+g+fl_r, :, :) = 0.0_rk
+            do ix = g+1, Bs(1)+g, s
+                do shift = fl_l, fl_r
+                    ! ignore the edge parts where we do not need a filter value from for further dimensions: g+1+fl_l:Bs+g+fl_r
+                    u_filtered(ix, g+1+fl_l:Bs(2)+g+fl_r, :, :) = u_filtered(ix, g+1+fl_l:Bs(2)+g+fl_r, :, :) &
+                    + u_tmp(ix+shift, g+1+fl_l:Bs(2)+g+fl_r, :, :)*coefs_filter(shift)
+                enddo
             enddo
-        enddo
+        else
+            u_filtered(g+1:Bs(1)+g:s, g+1+fl_l:Bs(2)+g+fl_r, g+1+fl_l:Bs(3)+g+fl_r, :) = 0.0_rk
+            do ix = g+1, Bs(1)+g, s
+                do shift = fl_l, fl_r
+                    ! ignore the edge parts where we do not need a filter value from for further dimensions: g+1+fl_l:Bs+g+fl_r
+                    u_filtered(ix, g+1+fl_l:Bs(2)+g+fl_r, g+1+fl_l:Bs(3)+g+fl_r, :) = u_filtered(ix, g+1+fl_l:Bs(2)+g+fl_r, g+1+fl_l:Bs(3)+g+fl_r, :) &
+                    + u_tmp(ix+shift, g+1+fl_l:Bs(2)+g+fl_r, g+1+fl_l:Bs(3)+g+fl_r, :)*coefs_filter(shift)
+                enddo
+            enddo
+        endif
 
         u_tmp = u_filtered
         u_filtered = u_tmp
-        u_filtered(:, g+1:Bs(2)+g, :, :) = 0.0_rk
-        do iy = g+1, Bs(2)+g
-            do shift = a, b
-                u_filtered(:, iy, :, :) = u_filtered(:, iy, :, :) + u_tmp(:, iy+shift, :, :)*coefs_filter(shift)
+        if (nz == 1) then
+            u_filtered(g+1:Bs(1)+g:s, g+1:Bs(2)+g:s, :, :) = 0.0_rk
+            do iy = g+1, Bs(2)+g, s
+                do shift = fl_l, fl_r
+                    ! ignore the edge parts where we do not need a filter value from for further dimensions: g+1+fl_l:Bs+g+fl_r
+                    u_filtered(g+1:Bs(1)+g:s, iy, :, :) = u_filtered(g+1:Bs(1)+g:s, iy, :, :) &
+                       + u_tmp(g+1:Bs(1)+g:s, iy+shift, :, :)*coefs_filter(shift)
+                enddo
             enddo
-        enddo
+        else
+            u_filtered(g+1:Bs(1)+g:s, g+1:Bs(2)+g:s, g+1+fl_l:Bs(3)+g+fl_r, :) = 0.0_rk
+            do iy = g+1, Bs(2)+g, s
+                do shift = fl_l, fl_r
+                    ! ignore the edge parts where we do not need a filter value from for further dimensions: g+1+fl_l:Bs+g+fl_r
+                    u_filtered(g+1:Bs(1)+g:s, iy, g+1+fl_l:Bs(3)+g+fl_r, :) = u_filtered(g+1:Bs(1)+g:s, iy, g+1+fl_l:Bs(3)+g+fl_r, :) &
+                       + u_tmp(g+1:Bs(1)+g:s, iy+shift, g+1+fl_l:Bs(3)+g+fl_r, :)*coefs_filter(shift)
+                enddo
+            enddo
+        endif
 
 
         if (nz == 1) return
 
         u_tmp = u_filtered
         u_filtered = u_tmp
-        u_filtered(:, :, g+1:Bs(3)+g, :) = 0.0_rk
-        do iz = g+1, Bs(3)+g
-            do shift = a, b
-                u_filtered(:, :, iz, :) = u_filtered(:, :, iz, :) + u_tmp(:, :, iz+shift, :)*coefs_filter(shift)
+        u_filtered(g+1:Bs(1)+g:s, g+1:Bs(2)+g:s, g+1:Bs(3)+g:s, :) = 0.0_rk
+        do iz = g+1, Bs(3)+g, s
+            do shift = fl_l, fl_r
+                u_filtered(g+1:Bs(1)+g:s, g+1:Bs(2)+g:s, iz, :) = u_filtered(g+1:Bs(1)+g:s, g+1:Bs(2)+g:s, iz, :) &
+                   + u_tmp(g+1:Bs(1)+g:s, g+1:Bs(2)+g:s, iz+shift, :)*coefs_filter(shift)
             enddo
         enddo
 
@@ -462,33 +508,47 @@ contains
 
     ! filter everywhere where possible: do not start at the interior points, but
     ! start at the support of the filter
-    !
-    ! g g g g g g g g g g g          g g g g g g g g g g g
-    ! g g g g g g g g g g g          g f f f f f f f f f g
-    ! g g i i i i i i i g g          g f f f f f f f f f g
-    ! g g i i i i i i i g g          g f f f f f f f f f g
-    ! g g i i i i i i i g g          g f f f f f f f f f g
-    ! g g i i i i i i i g g          g f f f f f f f f f g
-    ! g g i i i i i i i g g          g f f f f f f f f f g
-    ! g g i i i i i i i g g          g f f f f f f f f f g
-    ! g g g g g g g g g g g          g f f f f f f f f f g
-    ! g g g g g g g g g g g          g g g g g g g g g g g
-    ! Fig1: g= ghost i=internal      Fig2: f=filtered
-    subroutine blockFilterXYZ_wherePossible_vct( params, u, u_filtered, coefs_filter, a, b)
+    ! Bs=6, g=2, HD=[-1:1]
+    ! g g g g g g g g g g          g p p p p p p p p g          g p g p g p g p g g
+    ! g g g g g g g g g g          g f f f f f f f f g          g p g p g p g p g g
+    ! g g i i i i i i g g          g f f f f f f f f g          g f i f i f i f p g
+    ! g g i i i i i i g g          g f f f f f f f f g          g p i p i p i p g g
+    ! g g i i i i i i g g          g f f f f f f f f g          g f i f i f i f p g
+    ! g g i i i i i i g g          g f f f f f f f f g          g p i p i p i p g g
+    ! g g i i i i i i g g          g f f f f f f f f g          g f i f i f i f p g
+    ! g g i i i i i i g g          g f f f f f f f f g          g p i p i p i p g g
+    ! g g g g g g g g g g          g f f f f f f f f g          g f i f i f i f p g
+    ! g g g g g g g g g g          g p p p p p p p p g          g p p p p p p p p g
+    ! Fig1: input                    Fig2: out filtered           Fig3: filtered with restriction
+    ! g= ghost i=internal f=filtered p=partially filtered
+    ! For filtered: After the first dimension filtering we can ignore the edge-values (left and right side), this might not seem much for a full block
+    !       but for ghost patches we sometimes have very small patches with large support
+    ! For filtered with restriction: Every dimension we only filter the restricted points (so NOT every second and at edges where filter cannot be applied)
+    !       Afterwards, the next filtering considers for this dimension only those values so we have computing costs of (1/2 + 1/4 + 1/8) / 3 instead of 1
+    ! As edges can be partially filtered or not they should not be used!
+    subroutine blockFilterXYZ_wherePossible_vct( params, u, u_filtered, coefs_filter, fl_l, fl_r, do_restriction)
         implicit none
         type (type_params), intent(in) :: params
         real(kind=rk), dimension(1:,1:,1:,1:), intent(in) :: u
         real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u_filtered
-        integer(kind=ik) :: a, b
-        real(kind=rk), intent(in) :: coefs_filter(a:b)
+        integer(kind=ik), intent(in) :: fl_l, fl_r  !< Filter length left and right
+        real(kind=rk), intent(in) :: coefs_filter(fl_l:fl_r)
+        logical, intent(in), optional :: do_restriction  !< when we do restriction anyways we can skip every second point
+
         integer(kind=ik) :: ix, iy, iz, nx, ny, nz, nc, shift, g, Bs(1:3)
         real(kind=rk), allocatable, save :: u_tmp(:,:,:,:)
+        integer(kind=ik) :: s  ! sample_num, is either 1 or 2
 
         ! if the filter is just 1, then we copy and we're done.
         ! Yes, we use such stupid filters. They are in the CDFX0 wavelets (X=2,4)
-        if (a==0 .and. b==0 .and. abs(coefs_filter(0)-1.0_rk)<=1.0e-10_rk) then
+        if (fl_l==0 .and. fl_r==0 .and. abs(coefs_filter(0)-1.0_rk)<=1.0e-10_rk) then
             u_filtered = u
             return
+        endif
+
+        s = 1
+        if (present(do_restriction)) then
+            if (do_restriction) s = 2
         endif
 
 
@@ -499,28 +559,30 @@ contains
         g  = params%g
         Bs = params%Bs
 
-        if ((abs(a) > g).or.(b>g)) then
-            write(*,*) a, b, "but g=", g
+        if ((abs(fl_l) > g).or.(fl_r>g)) then
+            write(*,*) fl_l, fl_r, "but g=", g
             call abort(202302209, "For applying the filter, not enough ghost nodes")
         endif
 
         if (.not. allocated(u_tmp)) allocate( u_tmp(1:nx,1:ny,1:nz,1:nc) )
         u_tmp = u
 
-        u_filtered = u_tmp
-        u_filtered(-a+1:nx-b, :, :, :) = 0.0_rk
-        do ix = -a+1, nx-b
-            do shift = a, b
+        u_filtered = u_tmp  ! copy everything
+        u_filtered(-fl_l+1:nx-fl_r:s, :, :, :) = 0.0_rk  ! these values will be filtered and overwritten
+        do ix = -fl_l+1, nx-fl_r, s
+            do shift = fl_l, fl_r
                 u_filtered(ix, :, :, :) = u_filtered(ix, :, :, :) + u_tmp(ix+shift, :, :, :)*coefs_filter(shift)
             enddo
         enddo
 
         u_tmp = u_filtered
-        u_filtered = u_tmp
-        u_filtered(:, -a+1:ny-b, :, :) = 0.0_rk
-        do iy = -a+1, ny-b
-            do shift = a, b
-                u_filtered(:, iy, :, :) = u_filtered(:, iy, :, :) + u_tmp(:, iy+shift, :, :)*coefs_filter(shift)
+        ! u_filtered = u_tmp  ! not necessary
+        u_filtered(-fl_l+1:nx-fl_r:s, -fl_l+1:ny-fl_r:s, :, :) = 0.0_rk  ! these values will be filtered and overwritten again
+        do iy = -fl_l+1, ny-fl_r, s
+            do shift = fl_l, fl_r
+                ! after previous filtering we can ignore some x-values which were not effected to decrease the computational load
+                u_filtered(-fl_l+1:nx-fl_r:s, iy, :, :) = u_filtered(-fl_l+1:nx-fl_r:s, iy, :, :) &
+                   + u_tmp(-fl_l+1:nx-fl_r:s, iy+shift, :, :)*coefs_filter(shift)
             enddo
         enddo
 
@@ -528,11 +590,13 @@ contains
         if (nz == 1) return
 
         u_tmp = u_filtered
-        u_filtered = u_tmp
-        u_filtered(:, :, -a+1:nz-b, :) = 0.0_rk
-        do iz = -a+1, nz-b
-            do shift = a, b
-                u_filtered(:, :, iz, :) = u_filtered(:, :, iz, :) + u_tmp(:, :, iz+shift, :)*coefs_filter(shift)
+        ! u_filtered = u_tmp  ! not necessary
+        u_filtered(-fl_l+1:nx-fl_r:s, -fl_l+1:ny-fl_r:s, -fl_l+1:nz-fl_r:s, :) = 0.0_rk  ! these values will be filtered and overwritten again
+        do iz = -fl_l+1, nz-fl_r, s
+            do shift = fl_l, fl_r
+                ! after previous filtering we can ignore some x- and y-values which were not effected to decrease the computational load
+                u_filtered(-fl_l+1:nx-fl_r:s, -fl_l+1:ny-fl_r:s, iz, :) = u_filtered(-fl_l+1:nx-fl_r:s, -fl_l+1:ny-fl_r:s, iz, :) &
+                   + u_tmp(-fl_l+1:nx-fl_r:s, -fl_l+1:ny-fl_r:s, iz+shift, :)*coefs_filter(shift)
             enddo
         enddo
 
@@ -620,6 +684,7 @@ contains
 !     end subroutine
 
     ! applies one of params% HD GD HR GR filters in each direction
+    ! ToDo: for HD and GD filter, we might benefit from considering restriction, for HR from skipping points
     subroutine blockFilterCustom_vct( params, u, u_filtered, filter_x, filter_y, filter_z )
         implicit none
         type (type_params), intent(in) :: params
@@ -806,6 +871,7 @@ contains
 
     !-------------------------------------------------------------------------------
     ! applies one of params% HD GD HR GR filters in one direction
+    ! ToDo: for HD and GD filter, we might benefit from considering restriction, for HR from skipping points
     subroutine blockFilterCustom1_vct( params, u, u_filtered, filter, direction )
         implicit none
         type (type_params), intent(in) :: params
@@ -1096,539 +1162,6 @@ contains
 
     end subroutine
 
-    ! Inflated Mallat ordering is a HACK. I was just easier to code.
-    ! That does not mean its wrong, it isn't. But is uses extra memory (although
-    ! that is negligible) and does unnecessary copy actions.
-    subroutine spaghetti2inflatedMallat_block(params, u, wc)
-        implicit none
-        type (type_params), intent(in) :: params
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
-        ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-        ! Note: the precise naming of SC/WC is not really important. we just apply
-        ! the correct decomposition/reconstruction filters - thats it.
-        !
-        ! INDEX            2D     3D     LABEL
-        ! -----            --    ---     ---------------------------------
-        ! wc(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
-        ! wc(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
-        ! wc(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
-        ! wc(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
-        ! wc(:,:,:,:,5)          HHG     wcz wavelet coeffs
-        ! wc(:,:,:,:,6)          HGG     wcxz wavelet coeffs
-        ! wc(:,:,:,:,7)          GHG     wcyz wavelet coeffs
-        ! wc(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
-        !
-        real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: wc
-        integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
-
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        nc = size(u, 4)
-        g  = params%g
-        Bs = params%bs
-
-#ifdef DEV
-        if (.not.areArraysSameSize(u, wc(:,:,:,:,1))) then
-            call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
-        endif
-#endif
-
-        wc = 0.0_rk
-
-        ! note that what we call "Mallat ordering" here is in fact the "inflated" Mallat
-        ! in the sense that Nx*Ny data gives 4/8 * Nx*Ny decomposition.
-
-        ! copy from Spaghetti to inflated Mallat ordering
-        if (modulo(g, 2) == 0) then
-            ! even g
-            if (params%dim == 2) then
-                wc( 1:nx:2, 1:ny:2, :, :, 1) = u(1:nx:2, 1:ny:2, :, :)
-                wc( 1:nx:2, 1:ny:2, :, :, 2) = u(2:nx:2, 1:ny:2, :, :)
-                wc( 1:nx:2, 1:ny:2, :, :, 3) = u(1:nx:2, 2:ny:2, :, :)
-                wc( 1:nx:2, 1:ny:2, :, :, 4) = u(2:nx:2, 2:ny:2, :, :)
-            else
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 1) = u(1:nx:2, 1:ny:2, 1:nz:2, :)
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 2) = u(2:nx:2, 1:ny:2, 1:nz:2, :)
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 3) = u(1:nx:2, 2:ny:2, 1:nz:2, :)
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 4) = u(2:nx:2, 2:ny:2, 1:nz:2, :)
-
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 5) = u(1:nx:2, 1:ny:2, 2:nz:2, :)
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 6) = u(2:nx:2, 1:ny:2, 2:nz:2, :)
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 7) = u(1:nx:2, 2:ny:2, 2:nz:2, :)
-                wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 8) = u(2:nx:2, 2:ny:2, 2:nz:2, :)
-            endif
-        else
-            ! odd g
-            if (params%dim == 2) then
-                wc( 2:nx-1:2, 2:ny-1:2, :, :, 1) = u(2:nx-1:2, 2:ny-1:2, :, :)
-                wc( 2:nx-1:2, 2:ny-1:2, :, :, 2) = u(3:nx:2  , 2:ny-1:2  , :, :)
-                wc( 2:nx-1:2, 2:ny-1:2, :, :, 3) = u(2:nx-1:2, 3:ny:2  , :, :)
-                wc( 2:nx-1:2, 2:ny-1:2, :, :, 4) = u(3:nx:2  , 3:ny:2    , :, :)
-            else
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 1) = u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :)
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 2) = u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :)
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 3) = u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :)
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 4) = u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :)
-
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 5) = u(2:nx-1:2, 2:ny-1:2, 3:nz:2, :)
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 6) = u(3:nx:2  , 2:ny-1:2, 3:nz:2, :)
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 7) = u(2:nx-1:2, 3:ny:2  , 3:nz:2, :)
-                wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 8) = u(3:nx:2  , 3:ny:2  , 3:nz:2, :)
-            endif
-        endif
-    end subroutine
-
-
-    ! Inflated Mallat ordering is a HACK. I was just easier to code.
-    ! That does not mean its wrong, it isn't. But is uses extra memory (although
-    ! that is negligible) and does unnecessary copy actions.
-    subroutine inflatedMallat2spaghetti_block(params, wc, u, sc_only)
-        implicit none
-        type (type_params), intent(in) :: params
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
-        ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-        ! Note: the precise naming of SC/WC is not really important. we just apply
-        ! the correct decomposition/reconstruction filters - thats it.
-        !
-        ! INDEX            2D     3D     LABEL
-        ! -----            --    ---     ---------------------------------
-        ! wc(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
-        ! wc(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
-        ! wc(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
-        ! wc(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
-        ! wc(:,:,:,:,5)          HHG     wcz wavelet coeffs
-        ! wc(:,:,:,:,6)          HGG     wcxz wavelet coeffs
-        ! wc(:,:,:,:,7)          GHG     wcyz wavelet coeffs
-        ! wc(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
-        !
-        real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: wc
-        !> Option to only convert SC
-        logical, optional, intent(in)  :: sc_only
-
-        integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3), i_s, i_e
-        logical sc_only_set
-
-        sc_only_set = .false.
-        if (present(sc_only)) sc_only_set = sc_only
-
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        nc = size(u, 4)
-        g  = params%g
-        Bs = params%bs
-
-#ifdef DEV
-        if (.not.areArraysSameSize(u, wc(:,:,:,:,1))) then
-            call abort(27222119, "Allocated arrays are not compatible?! Time for a drink. You look handsome today.")
-        endif
-#endif
-
-        ! note that what we call "Mallat ordering" here is in fact the "inflated" Mallat
-        ! in the sense that Nx*Ny data gives 4/8 * Nx*Ny decomposition.
-
-        ! compute index shift for odd g, ignoring outmost elements
-        i_s = 1 + modulo(g, 2)  ! 1 for even, 2 for odd
-        i_e = 0 + modulo(g, 2)  ! 0 for even, 1 for odd
-
-        ! copy from inflated Mallat to Mallat ordering
-        if (params%dim == 2) then
-            u(       i_s:nx-i_e:2,   i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 1)
-            if (.not. sc_only_set) then
-                u( 1+i_s:nx-i_e:2,   i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 2)
-                u(   i_s:nx-i_e:2, 1+i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 3)
-                u( 1+i_s:nx-i_e:2, 1+i_s:ny-i_e:2, :, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 4)
-            endif
-        else
-            u(       i_s:nx-i_e:2,   i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 1)
-            if (.not. sc_only_set) then
-                u( 1+i_s:nx-i_e:2,   i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 2)
-                u(   i_s:nx-i_e:2, 1+i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 3)
-                u( 1+i_s:nx-i_e:2, 1+i_s:ny-i_e:2,   i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 4)
-
-                u(   i_s:nx-i_e:2,   i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 5)
-                u( 1+i_s:nx-i_e:2,   i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 6)
-                u(   i_s:nx-i_e:2, 1+i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 7)
-                u( 1+i_s:nx-i_e:2, 1+i_s:ny-i_e:2, 1+i_s:nz-i_e:2, :) = wc( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 8)
-            endif
-        endif
-
-        ! ! copy from inflated Mallat to Spaghetti ordering
-        ! if (modulo(g, 2) == 0) then
-        !     ! even g
-        !     if (params%dim == 2) then
-        !         u(1:nx:2, 1:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 1)
-        !         u(2:nx:2, 1:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 2)
-        !         u(1:nx:2, 2:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 3)
-        !         u(2:nx:2, 2:ny:2, :, :) = wc( 1:nx:2, 1:ny:2, :, :, 4)
-        !     else
-        !         u(1:nx:2, 1:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 1)
-        !         u(2:nx:2, 1:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 2)
-        !         u(1:nx:2, 2:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 3)
-        !         u(2:nx:2, 2:ny:2, 1:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 4)
-
-        !         u(1:nx:2, 1:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 5)
-        !         u(2:nx:2, 1:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 6)
-        !         u(1:nx:2, 2:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 7)
-        !         u(2:nx:2, 2:ny:2, 2:nz:2, :) = wc( 1:nx:2, 1:ny:2, 1:nz:2, :, 8)
-        !     endif
-        ! else
-        !     ! odd g
-        !     if (params%dim == 2) then
-        !         u(2:nx-1:2, 2:ny-1:2, :, :) = wc( 2:nx-1:2, 2:ny-1:2, :, :, 1)
-        !         u(3:nx:2  , 2:ny-1:2, :, :) = wc( 2:nx-1:2, 2:ny-1:2, :, :, 2)
-        !         u(2:nx-1:2, 3:ny:2, :, :)   = wc( 2:nx-1:2, 2:ny-1:2, :, :, 3)
-        !         u(3:nx:2  , 3:ny:2, :, :)   = wc( 2:nx-1:2, 2:ny-1:2, :, :, 4)
-        !     else
-        !         u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 1)
-        !         u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 2)
-        !         u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 3)
-        !         u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 4)
-
-        !         u(2:nx-1:2, 2:ny-1:2, 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 5)
-        !         u(3:nx:2  , 2:ny-1:2, 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 6)
-        !         u(2:nx-1:2, 3:ny:2  , 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 7)
-        !         u(3:nx:2  , 3:ny:2  , 3:nz:2, :) = wc( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 8)
-        !     endif
-        ! endif
-
-    end subroutine
-
-
-    subroutine spaghetti2Mallat_block(params, u, wc)
-        implicit none
-        type (type_params), intent(in) :: params
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
-        ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-        ! Note: the precise naming of SC/WC is not really important. we just apply
-        ! the correct decomposition/reconstruction filters - thats it.
-        !
-        ! INDEX                                        2D     3D     LABEL
-        ! -----------------------------------------    --    ---     ---------------------------------
-        ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
-        ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
-        !
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
-        integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
-
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        nc = size(u, 4)
-        g  = params%g
-        Bs = params%bs
-
-#ifdef DEV
-        if (.not.areArraysSameSize(u, wc)) then
-            call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
-        endif
-#endif
-
-        wc = 0.0_rk
-
-        ! copy from Spaghetti to Mallat ordering
-        if (modulo(g, 2) == 0) then
-            ! even g
-            if (params%dim == 2) then
-                wc(      1:nx/2,      1:ny/2, :, :) = u(1:nx:2, 1:ny:2, :, :)
-                wc(      1:nx/2, ny/2+1:ny  , :, :) = u(2:nx:2, 1:ny:2, :, :)
-                wc( nx/2+1:nx  ,      1:ny/2, :, :) = u(1:nx:2, 2:ny:2, :, :)
-                wc( nx/2+1:nx  , ny/2+1:ny  , :, :) = u(2:nx:2, 2:ny:2, :, :)
-            else
-                wc(      1:nx/2,      1:ny/2,      1:nz/2, :) = u(1:nx:2, 1:ny:2, 1:nz:2, :)
-                wc(      1:nx/2, ny/2+1:ny  ,      1:nz/2, :) = u(2:nx:2, 1:ny:2, 1:nz:2, :)
-                wc( nx/2+1:nx  ,      1:ny/2,      1:nz/2, :) = u(1:nx:2, 2:ny:2, 1:nz:2, :)
-                wc( nx/2+1:nx  , ny/2+1:ny  ,      1:nz/2, :) = u(2:nx:2, 2:ny:2, 1:nz:2, :)
-
-                wc(      1:nx/2,      1:ny/2, nz/2+1:nz  , :) = u(1:nx:2, 1:ny:2, 2:nz:2, :)
-                wc(      1:nx/2, ny/2+1:ny  , nz/2+1:nz  , :) = u(2:nx:2, 1:ny:2, 2:nz:2, :)
-                wc( nx/2+1:nx  ,      1:ny/2, nz/2+1:nz  , :) = u(1:nx:2, 2:ny:2, 2:nz:2, :)
-                wc( nx/2+1:nx  , ny/2+1:ny  , nz/2+1:nz  , :) = u(2:nx:2, 2:ny:2, 2:nz:2, :)
-            endif
-        else
-            ! odd g
-            if (params%dim == 2) then
-                wc(      2:nx/2,      2:ny/2, :, :) = u(2:nx-1:2, 2:ny-1:2, :, :)
-                wc(      2:nx/2, ny/2+1:ny-1, :, :) = u(3:nx:2  , 2:ny-1:2, :, :)
-                wc( nx/2+1:nx-1,      2:ny/2, :, :) = u(2:nx-1:2, 3:ny:2  , :, :)
-                wc( nx/2+1:nx-1, ny/2+1:ny-1, :, :) = u(3:nx:2  , 3:ny:2  , :, :)
-            else
-                wc(      2:nx/2,      2:ny/2,      2:nz/2, :) = u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :)
-                wc(      2:nx/2, ny/2+1:ny-1,      2:nz/2, :) = u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :)
-                wc( nx/2+1:nx-1,      2:ny/2,      2:nz/2, :) = u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :)
-                wc( nx/2+1:nx-1, ny/2+1:ny-1,      2:nz/2, :) = u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :)
-
-                wc(      2:nx/2,      2:ny/2, nz/2+1:nz-1, :) = u(2:nx-1:2, 2:ny-1:2, 3:nz:2  , :)
-                wc(      2:nx/2, ny/2+1:ny-1, nz/2+1:nz-1, :) = u(3:nx:2  , 2:ny-1:2, 3:nz:2  , :)
-                wc( nx/2+1:nx-1,      2:ny/2, nz/2+1:nz-1, :) = u(2:nx-1:2, 3:ny:2  , 3:nz:2  , :)
-                wc( nx/2+1:nx-1, ny/2+1:ny-1, nz/2+1:nz-1, :) = u(3:nx:2  , 3:ny:2  , 3:nz:2  , :)
-            endif
-        endif
-    end subroutine
-
-
-
-    subroutine Mallat2Spaghetti_block(params, wc, u)
-        implicit none
-        type (type_params), intent(in) :: params
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: u
-        ! The WC array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-        ! Note: the precise naming of SC/WC is not really important. we just apply
-        ! the correct decomposition/reconstruction filters - thats it.
-        !
-        ! INDEX                                        2D     3D     LABEL
-        ! -----------------------------------------    --    ---     ---------------------------------
-        ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
-        ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
-        !
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
-        integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
-
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        nc = size(u, 4)
-        g  = params%g
-        Bs = params%bs
-
-#ifdef DEV
-        if (.not.areArraysSameSize(u, wc)) then
-            call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
-        endif
-#endif
-
-        u = 0.0_rk
-
-        ! copy from Mallat to Spaghetti ordering
-        if (modulo(g, 2) == 0) then
-            ! even g
-            if (params%dim == 2) then
-                u(1:nx:2, 1:ny:2, :, :) = wc(      1:nx/2,      1:ny/2, :, :)
-                u(2:nx:2, 1:ny:2, :, :) = wc(      1:nx/2, ny/2+1:ny  , :, :)
-                u(1:nx:2, 2:ny:2, :, :) = wc( nx/2+1:nx  ,      1:ny/2, :, :)
-                u(2:nx:2, 2:ny:2, :, :) = wc( nx/2+1:nx  , ny/2+1:ny  , :, :)
-            else
-                u(1:nx:2, 1:ny:2, 1:nz:2, :) = wc(      1:nx/2,      1:ny/2,      1:nz/2, :)
-                u(2:nx:2, 1:ny:2, 1:nz:2, :) = wc(      1:nx/2, ny/2+1:ny  ,      1:nz/2, :)
-                u(1:nx:2, 2:ny:2, 1:nz:2, :) = wc( nx/2+1:nx  ,      1:ny/2,      1:nz/2, :)
-                u(2:nx:2, 2:ny:2, 1:nz:2, :) = wc( nx/2+1:nx  , ny/2+1:ny  ,      1:nz/2, :)
-
-                u(1:nx:2, 1:ny:2, 2:nz:2, :) = wc(      1:nx/2,      1:ny/2, nz/2+1:nz  , :)
-                u(2:nx:2, 1:ny:2, 2:nz:2, :) = wc(      1:nx/2, ny/2+1:ny  , nz/2+1:nz  , :)
-                u(1:nx:2, 2:ny:2, 2:nz:2, :) = wc( nx/2+1:nx  ,      1:ny/2, nz/2+1:nz  , :)
-                u(2:nx:2, 2:ny:2, 2:nz:2, :) = wc( nx/2+1:nx  , ny/2+1:ny  , nz/2+1:nz  , :)
-            endif
-        else
-            ! odd g
-            if (params%dim == 2) then
-                u(2:nx-1:2, 2:ny-1:2, :, :) = wc(      2:nx/2,      2:ny/2, :, :)
-                u(3:nx:2  , 2:ny-1:2, :, :) = wc(      2:nx/2, ny/2+1:ny-1, :, :)
-                u(2:nx-1:2, 3:ny:2  , :, :) = wc( nx/2+1:nx-1,      2:ny/2, :, :)
-                u(3:nx:2  , 3:ny:2  , :, :) = wc( nx/2+1:nx-1, ny/2+1:ny-1, :, :)
-            else
-                u(2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :) = wc(      2:nx/2,      2:ny/2,      2:nz/2, :)
-                u(3:nx:2  , 2:ny-1:2, 2:nz-1:2, :) = wc(      2:nx/2, ny/2+1:ny-1,      2:nz/2, :)
-                u(2:nx-1:2, 3:ny:2  , 2:nz-1:2, :) = wc( nx/2+1:nx-1,      2:ny/2,      2:nz/2, :)
-                u(3:nx:2  , 3:ny:2  , 2:nz-1:2, :) = wc( nx/2+1:nx-1, ny/2+1:ny-1,      2:nz/2, :)
-
-                u(2:nx-1:2, 2:ny-1:2, 3:nz:2  , :) = wc(      2:nx/2,      2:ny/2, nz/2+1:nz-1, :)
-                u(3:nx:2  , 2:ny-1:2, 3:nz:2  , :) = wc(      2:nx/2, ny/2+1:ny-1, nz/2+1:nz-1, :)
-                u(2:nx-1:2, 3:ny:2  , 3:nz:2  , :) = wc( nx/2+1:nx-1,      2:ny/2, nz/2+1:nz-1, :)
-                u(3:nx:2  , 3:ny:2  , 3:nz:2  , :) = wc( nx/2+1:nx-1, ny/2+1:ny-1, nz/2+1:nz-1, :)
-            endif
-        endif
-    end subroutine
-
-
-
-    ! Inflated Mallat ordering is a HACK. I was just easier to code.
-    ! That does not mean its wrong, it isn't. But is uses extra memory (although
-    ! that is negligible) and does unnecessary copy actions.
-    subroutine Mallat2inflatedMallat_block(params, wc, u)
-        implicit none
-        type (type_params), intent(in) :: params
-        ! The WC and u array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-        ! Note: the precise naming of SC/WC is not really important. we just apply
-        ! the correct decomposition/reconstruction filters - thats it.
-        !
-        ! INDEX                                        2D     3D     LABEL
-        ! -----------------------------------------    --    ---     ---------------------------------
-        ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
-        ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
-        ! INDEX            2D     3D     LABEL
-        ! -----            --    ---     ---------------------------------
-        ! u(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
-        ! u(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
-        ! u(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
-        ! u(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
-        ! u(:,:,:,:,5)          HHG     wcz wavelet coeffs
-        ! u(:,:,:,:,6)          HGG     wcxz wavelet coeffs
-        ! u(:,:,:,:,7)          GHG     wcyz wavelet coeffs
-        ! u(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
-        real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: u
-
-        integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
-
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        nc = size(u, 4)
-        g  = params%g
-        Bs = params%bs
-
-#ifdef DEV
-        if (.not.areArraysSameSize(wc, u(:,:,:,:,1))) then
-            call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
-        endif
-#endif
-
-        u = 0.0_rk
-
-        ! copy from Mallat to inflated Mallat ordering
-        if (modulo(g, 2) == 0) then
-            ! even g
-            if (params%dim == 2) then
-                u( 1:nx:2, 1:ny:2, :, :, 1) = wc(      1:nx/2,      1:ny/2, :, :)
-                u( 1:nx:2, 1:ny:2, :, :, 2) = wc(      1:nx/2, ny/2+1:ny  , :, :)
-                u( 1:nx:2, 1:ny:2, :, :, 3) = wc( nx/2+1:nx  ,      1:ny/2, :, :)
-                u( 1:nx:2, 1:ny:2, :, :, 4) = wc( nx/2+1:nx  , ny/2+1:ny  , :, :)
-            else
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 1) = wc(      1:nx/2,      1:ny/2,      1:nz/2, :)
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 2) = wc(      1:nx/2, ny/2+1:ny  ,      1:nz/2, :)
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 3) = wc( nx/2+1:nx  ,      1:ny/2,      1:nz/2, :)
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 4) = wc( nx/2+1:nx  , ny/2+1:ny  ,      1:nz/2, :)
-
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 5) = wc(      1:nx/2,      1:ny/2, nz/2+1:nz  , :)
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 6) = wc(      1:nx/2, ny/2+1:ny  , nz/2+1:nz  , :)
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 7) = wc( nx/2+1:nx  ,      1:ny/2, nz/2+1:nz  , :)
-                u( 1:nx:2, 1:ny:2, 1:nz:2, :, 8) = wc( nx/2+1:nx  , ny/2+1:ny  , nz/2+1:nz  , :)
-            endif
-        else
-            ! odd g
-            if (params%dim == 2) then
-                u( 2:nx-1:2, 2:ny-1:2, :, :, 1) = wc(      2:nx/2,      2:ny/2, :, :)
-                u( 2:nx-1:2, 2:ny-1:2, :, :, 2) = wc(      2:nx/2, ny/2+1:ny-1, :, :)
-                u( 2:nx-1:2, 2:ny-1:2, :, :, 3) = wc( nx/2+1:nx-1,      2:ny/2, :, :)
-                u( 2:nx-1:2, 2:ny-1:2, :, :, 4) = wc( nx/2+1:nx-1, ny/2+1:ny-1, :, :)
-            else
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 1) = wc(      2:nx/2,      2:ny/2,      2:nz/2, :)
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 2) = wc(      2:nx/2, ny/2+1:ny-1,      2:nz/2, :)
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 3) = wc( nx/2+1:nx-1,      2:ny/2,      2:nz/2, :)
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 4) = wc( nx/2+1:nx-1, ny/2+1:ny-1,      2:nz/2, :)
-
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 5) = wc(      2:nx/2,      2:ny/2, nz/2+1:nz-1, :)
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 6) = wc(      2:nx/2, ny/2+1:ny-1, nz/2+1:nz-1, :)
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 7) = wc( nx/2+1:nx-1,      2:ny/2, nz/2+1:nz-1, :)
-                u( 2:nx-1:2, 2:ny-1:2, 2:nz-1:2, :, 8) = wc( nx/2+1:nx-1, ny/2+1:ny-1, nz/2+1:nz-1, :)
-            endif
-        endif
-    end subroutine
-
-
-
-    ! Inflated Mallat ordering is a HACK. I was just easier to code.
-    ! That does not mean its wrong, it isn't. But is uses extra memory (although
-    ! that is negligible) and does unnecessary copy actions.
-    subroutine inflatedMallat2Mallat_block(params, u, wc, sc_only)
-        implicit none
-        type (type_params), intent(in) :: params
-        ! The WC and u array contains SC (scaling function coeffs) as well as all WC (wavelet coeffs)
-        ! Note: the precise naming of SC/WC is not really important. we just apply
-        ! the correct decomposition/reconstruction filters - thats it.
-        !
-        ! INDEX                                        2D     3D     LABEL
-        ! -----------------------------------------    --    ---     ---------------------------------
-        ! wc(     1:nx/2,     1:ny/2,     1:nz/2,:)    HH    HHH     sc scaling function coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,     1:nz/2,:)    HG    HGH     wcx wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,     1:nz/2,:)    GH    GHH     wcy wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,     1:nz/2,:)    GG    GGH     wcxy wavelet coeffs
-        ! wc(     1:nx/2,     1:ny/2,nz/2+1:nz  ,:)          HHG     wcz wavelet coeffs
-        ! wc(     1:nx/2,ny/2+1:ny  ,nz/2+1:nz  ,:)          HGG     wcxz wavelet coeffs
-        ! wc(nx/2+1:nx  ,     1:ny/2,nz/2+1:nz  ,:)          GHG     wcyz wavelet coeffs
-        ! wc(nx/2+1:nx  ,ny/2+1:ny  ,nz/2+1:nz  ,:)          GGG     wcxyz wavelet coeffs
-        real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
-        ! INDEX            2D     3D     LABEL
-        ! -----            --    ---     ---------------------------------
-        ! u(:,:,:,:,1)    HH    HHH     sc scaling function coeffs
-        ! u(:,:,:,:,2)    HG    HGH     wcx wavelet coeffs
-        ! u(:,:,:,:,3)    GH    GHH     wcy wavelet coeffs
-        ! u(:,:,:,:,4)    GG    GGH     wcxy wavelet coeffs
-        ! u(:,:,:,:,5)          HHG     wcz wavelet coeffs
-        ! u(:,:,:,:,6)          HGG     wcxz wavelet coeffs
-        ! u(:,:,:,:,7)          GHG     wcyz wavelet coeffs
-        ! u(:,:,:,:,8)          GGG     wcxyz wavelet coeffs
-        real(kind=rk), dimension(1:,1:,1:,1:,1:), intent(inout) :: u
-        !> Option to only convert SC
-        logical, optional, intent(in)  :: sc_only
-
-        integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3), i_s, i_e
-        logical sc_only_set
-
-        sc_only_set = .false.
-        if (present(sc_only)) sc_only_set = sc_only
-
-        nx = size(u, 1)
-        ny = size(u, 2)
-        nz = size(u, 3)
-        nc = size(u, 4)
-        g  = params%g
-        Bs = params%bs
-
-#ifdef DEV
-        if (.not.areArraysSameSize(wc, u(:,:,:,:,1))) then
-            call abort(27222119, "Allocated arrays are not compatible?! Time for a drink.")
-        endif
-#endif
-
-        wc = 0.0_rk
-
-        ! compute index shift for odd g, ignoring outmost elements
-        i_s = 1 + modulo(g, 2)  ! 1 for even, 2 for odd
-        i_e = 0 + modulo(g, 2)  ! 0 for even, 1 for odd
-
-        ! copy from inflated Mallat to Mallat ordering
-        if (params%dim == 2) then
-            wc(        i_s:nx/2  ,    i_s:ny/2  , :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 1)
-            if (.not. sc_only_set) then
-                wc(    i_s:nx/2  , ny/2+1:ny-i_e, :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 2)
-                wc( nx/2+1:nx-i_e,    i_s:ny/2  , :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 3)
-                wc( nx/2+1:nx-i_e, ny/2+1:ny-i_e, :, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, :, :, 4)
-            endif
-        else
-            wc(        i_s:nx/2  ,    i_s:ny/2  ,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 1)
-            if (.not. sc_only_set) then
-                wc(    i_s:nx/2  , ny/2+1:ny-i_e,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 2)
-                wc( nx/2+1:nx-i_e,    i_s:ny/2  ,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 3)
-                wc( nx/2+1:nx-i_e, ny/2+1:ny-i_e,    i_s:nz/2  , :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 4)
-        
-                wc(    i_s:nx/2  ,    i_s:ny/2  , nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 5)
-                wc(    i_s:nx/2  , ny/2+1:ny-i_e, nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 6)
-                wc( nx/2+1:nx-i_e,    i_s:ny/2  , nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 7)
-                wc( nx/2+1:nx-i_e, ny/2+1:ny-i_e, nz/2+1:nz-i_e, :) = u( i_s:nx-i_e:2, i_s:ny-i_e:2, i_s:nz-i_e:2, :, 8)
-            endif
-        endif
-    end subroutine
-
 
 
     ! manipulate wavelet coefficients in a neighborhood direction: applied
@@ -1682,7 +1215,7 @@ contains
 
 
 
-    subroutine coarseExtensionManipulateSC_block(params, wc, u_copy, neighborhood, skip_ghosts)
+    subroutine coarseExtensionManipulateSC_block(params, wc, u_copy, neighborhood, skip_ghosts, ijk)
         implicit none
 
         type (type_params), intent(in) :: params
@@ -1705,9 +1238,11 @@ contains
         real(kind=rk), dimension(1:,1:,1:,1:), intent(inout) :: wc
         integer(kind=ik), intent(in)   :: neighborhood   !> Which neighborhood to apply manipulation
         logical, optional, intent(in)  :: skip_ghosts    !> Flag to skip ghost points if they have been synched
+        integer(kind=ik), intent(in), optional   :: ijk(2,3)       !< ijk of patch that we only care about, if not given it is the full block
 
         integer(kind=ik) :: nx, ny, nz, nc, g, Bs(1:3)
         integer(kind=ik) :: Nscl, Nscr, Nreconl, Nreconr, idx(2,3)
+        logical          :: skip_copy
 
         nx = size(wc, 1)
         ny = size(wc, 2)
@@ -1719,6 +1254,7 @@ contains
         Nscr    = params%Nscr
         Nreconl = params%Nreconl
         Nreconr = params%Nreconr
+        skip_copy = .false.
 
         idx(:, :) = 1
         ! Normally we also reset boundary values. However if they have been synched to the field we want to leave them as they are
@@ -1729,8 +1265,19 @@ contains
             call get_indices_of_modify_patch(params, neighborhood, idx, (/ nx, ny, nz/), (/Nscl, Nscl, Nscl/), (/Nscr, Nscr, Nscr/))
         endif
 
-        wc(idx(1,1):idx(2,1), idx(1,2):idx(2,2), idx(1,3):idx(2,3), 1:nc) = &
-            u_copy(idx(1,1):idx(2,1), idx(1,2):idx(2,2), idx(1,3):idx(2,3), 1:nc)
+        ! sometimes we do not want to look at the full block, then we can skip the copy where the indices do not matter
+        if (present(ijk)) then
+            ! check in each dimension if the indices lie outside the affected range
+            ! copy patch has to end before beginning of affected region or begin before end of affected region
+            if (idx(2,1) < ijk(1,1) .or. idx(1,1) > ijk(2,1)) skip_copy = .true.
+            if (idx(2,2) < ijk(1,2) .or. idx(1,2) > ijk(2,2)) skip_copy = .true.
+            if (idx(2,3) < ijk(1,3) .or. idx(1,3) > ijk(2,3) .and. params%dim == 3) skip_copy = .true.
+        endif
+
+        if (.not. skip_copy) then
+            wc(idx(1,1):idx(2,1), idx(1,2):idx(2,2), idx(1,3):idx(2,3), 1:nc) = &
+                u_copy(idx(1,1):idx(2,1), idx(1,2):idx(2,2), idx(1,3):idx(2,3), 1:nc)
+        endif
 
     end subroutine
 
@@ -2218,47 +1765,17 @@ contains
 
 
 
-
-
-
-    ! one-dimensional, periodized filter
-    subroutine filter1P(params, u, u_filtered, filter, a1, b1)
+    ! 1D filter, pass skip_g=params%g to skip ghost points, pass do_restriction to filter only every second point
+    subroutine filter1dim(params, u, u_filtered, filter, fl_l, fl_r, skip_g, sampling)
         implicit none
-        type (type_params), intent(in) :: params
-        ! filter bound indices
-        integer, intent(in) :: a1, b1
-        ! the actual filter
-        real(kind=rk), dimension(a1:b1), intent(in) :: filter
-        ! the signal to be filtered
-        real(kind=rk), dimension(1:), intent(in) :: u
-        ! the resulting filtered signal
-        real(kind=rk), dimension(1:), intent(inout) :: u_filtered
-
-        integer(kind=ik) :: N, i, j
-
-        N = size(u)
-        u_filtered = 0.0_rk
-
-        do i = 1, N
-            do j = a1, b1
-                u_filtered(i) = u_filtered(i) + u( perindex(i+j,N) ) * filter(j)
-            enddo
-        enddo
-
-    end subroutine
-
-    ! 1D filter excluding ghost nodes
-    subroutine filter1G(params, u, u_filtered, filter, a1, b1)
-        implicit none
-        type (type_params), intent(in) :: params
-        ! filter bound indices
-        integer, intent(in) :: a1, b1
-        ! the actual filter
-        real(kind=rk), dimension(a1:b1), intent(in) :: filter
-        ! the signal to be filtered
-        real(kind=rk), dimension(1:), intent(in) :: u
-        ! the resulting filtered signal
-        real(kind=rk), dimension(1:), intent(inout) :: u_filtered
+        type (type_params), intent(in) :: params                        !< good ol' params
+        real(kind=rk), dimension(1:), intent(in) :: u                   !< the signal to be filtered
+        real(kind=rk), dimension(1:), intent(inout) :: u_filtered       !< the resulting filtered signal
+        integer, intent(in) :: fl_l, fl_r                               !< filter bound indices left and right
+        real(kind=rk), dimension(fl_l:fl_r), intent(in) :: filter       !< the actual filter
+        integer, intent(in) :: skip_g                                   !< 0 to filter everything, params%g to skip ghost points
+        !> sampling rate, 1 for normal mode, 2 for restriction, no optional parameter as this is inside critical point-loop and I want to avoid if-clauses
+        integer, intent(in) :: sampling                                        
 
         integer(kind=ik) :: N, i, j
 
@@ -2266,13 +1783,16 @@ contains
         u_filtered = 0.0_rk
 
         ! apply filter f to periodic signal u, i.e. convolute with filter
-        do i =  params%g+1, N-params%g
-            do j = a1, b1
+        do i =  1+skip_g, N-skip_g, sampling
+            do j = fl_l, fl_r
                 u_filtered(i) = u_filtered(i) + u(i+j) * filter(j)
             enddo
         enddo
     end subroutine
 
+
+
+    ! for debugging
     subroutine dump_block(u, file)
         real(kind=rk), dimension(:, :, :, :), intent(in) :: u
         character(len=*) :: file
@@ -2330,10 +1850,10 @@ contains
             do iy = 1, ny
                 do iz = 1, nz
                     ! low-pass filter (scaling function)
-                    call filter1G(params, u_wc(:,iy,iz,ic), buffer1, params%HD, lbound(params%HD,dim=1), ubound(params%HD,dim=1))
+                    call filter1dim(params, u_wc(:,iy,iz,ic), buffer1, params%HD, lbound(params%HD,dim=1), ubound(params%HD,dim=1), skip_g=params%g, sampling=2)
 
                     ! high-pass filter (these guys are the details)
-                    call filter1G(params, u_wc(:,iy,iz,ic), buffer2, params%GD, lbound(params%GD,dim=1), ubound(params%GD,dim=1))
+                    call filter1dim(params, u_wc(:,iy,iz,ic), buffer2, params%GD, lbound(params%GD,dim=1), ubound(params%GD,dim=1), skip_g=params%g, sampling=2)
 
                     ! decimation by 2, sort into array
                     u_wc(1:Bs(1)/2,iy,iz,ic)       = buffer1( (g+1):(Bs(1)+g):2 )
@@ -2356,10 +1876,10 @@ contains
             do ix = 1, Bs(1)
                 do iz = 1, nz
                     ! low-pass filter (scaling function)
-                    call filter1G(params, u_wc(ix,:,iz,ic), buffer1, params%HD, lbound(params%HD,dim=1), ubound(params%HD,dim=1))
+                    call filter1dim(params, u_wc(ix,:,iz,ic), buffer1, params%HD, lbound(params%HD,dim=1), ubound(params%HD,dim=1), skip_g=params%g, sampling=2)
 
                     ! high-pass filter (these guys are the details)
-                    call filter1G(params, u_wc(ix,:,iz,ic), buffer2, params%GD, lbound(params%GD,dim=1), ubound(params%GD,dim=1))
+                    call filter1dim(params, u_wc(ix,:,iz,ic), buffer2, params%GD, lbound(params%GD,dim=1), ubound(params%GD,dim=1), skip_g=params%g, sampling=2)
 
                     ! decimation by 2, sort into array
                     u_wc(ix,1:Bs(2)/2,iz,ic)       = buffer1( (g+1):(Bs(2)+g):2 )
@@ -2383,10 +1903,10 @@ contains
                 do ix = 1, Bs(1)
                     do iy = 1, Bs(2)
                         ! low-pass filter (scaling function)
-                        call filter1G(params, u_wc(ix,iy,:,ic), buffer1, params%HD, lbound(params%HD,dim=1), ubound(params%HD,dim=1))
+                        call filter1dim(params, u_wc(ix,iy,:,ic), buffer1, params%HD, lbound(params%HD,dim=1), ubound(params%HD,dim=1), skip_g=params%g, sampling=2)
 
                         ! high-pass filter (these guys are the details)
-                        call filter1G(params, u_wc(ix,iy,:,ic), buffer2, params%GD, lbound(params%GD,dim=1), ubound(params%GD,dim=1))
+                        call filter1dim(params, u_wc(ix,iy,:,ic), buffer2, params%GD, lbound(params%GD,dim=1), ubound(params%GD,dim=1), skip_g=params%g, sampling=2)
 
                         ! decimation by 2, sort into array
                         u_wc(ix,iy,1:Bs(3)/2,ic)       = buffer1( (g+1):(Bs(3)+g):2 )
@@ -2557,12 +2077,12 @@ contains
                         buffer3 = 0.0_rk
                         ! even g: 1st point is collocation point
                         buffer3(1:nx-1:2) = u_wc_tmp(1:n(1), iy, iz, ic) ! SC
-                        call filter1G(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1))
+                        call filter1dim(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1), skip_g=params%g, sampling=1)
 
                         ! fill upsampling buffer for high-pass filter: every second point
                         buffer3 = 0.0_rk
                         buffer3(1:nx-1:2) = u_wc_tmp(n(1)+1:2*n(1), iy, iz, ic) ! WC
-                        call filter1G(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1))
+                        call filter1dim(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1), skip_g=params%g, sampling=1)
 
                         u_wc(:, iy, iz, ic) = buffer1 + buffer2
                     enddo
@@ -2589,12 +2109,12 @@ contains
                         ! apply low-pass filter to upsampled signal
                         buffer3 = 0.0_rk
                         buffer3(1:ny-1:2) = u_wc(ix, 1:n(2), iz, ic)
-                        call filter1G(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1))
+                        call filter1dim(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1), skip_g=params%g, sampling=1)
 
                         ! fill upsampling buffer for high-pass filter: every second point
                         buffer3 = 0.0_rk
                         buffer3(1:ny-1:2) = u_wc(ix, n(2)+1:2*n(2), iz, ic)
-                        call filter1G(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1))
+                        call filter1dim(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1), skip_g=params%g, sampling=1)
 
                         u_wc(ix, :, iz, ic) = buffer1 + buffer2
                     enddo
@@ -2626,12 +2146,12 @@ contains
                         ! apply low-pass filter to upsampled signal
                         buffer3 = 0.0_rk
                         buffer3(1:nz-1:2) = u_wc(ix, iy, 1:n(2), ic)
-                        call filter1G(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1))
+                        call filter1dim(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1), skip_g=params%g, sampling=1)
 
                         ! fill upsampling buffer for high-pass filter: every second point
                         buffer3 = 0.0_rk
                         buffer3(1:nz-1:2) = u_wc(ix, iy, n(2)+1:2*n(2), ic)
-                        call filter1G(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1))
+                        call filter1dim(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1), skip_g=params%g, sampling=1)
 
                         u_wc(ix, iy, :, ic) = buffer1 + buffer2
                     enddo
@@ -2707,13 +2227,13 @@ contains
                         buffer3 = 0.0_rk
                         ! odd g, 2nd point is collocation point
                         buffer3(2:nx:2) = u_wc_tmp(1:n(1), iy, iz, ic) ! SC
-                        call filter1G(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1))
+                        call filter1dim(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1), skip_g=params%g, sampling=1)
 
                         ! fill upsampling buffer for high-pass filter: every second point
                         buffer3 = 0.0_rk
                         buffer3(2:nx:2) = u_wc_tmp(n(1)+1:2*n(1), iy, iz, ic) ! WC
                         ! buffer3(1:nx-1:2) = u_wc_tmp(n(1)+1:2*n(1), iy, iz, ic) ! WC
-                        call filter1G(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1))
+                        call filter1dim(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1), skip_g=params%g, sampling=1)
 
                         u_wc(:, iy, iz, ic) = buffer2 + buffer1
                     enddo
@@ -2740,12 +2260,12 @@ contains
                         ! apply low-pass filter to upsampled signal
                         buffer3 = 0.0_rk
                         buffer3(2:ny:2) = u_wc(ix, 1:n(2), iz, ic)
-                        call filter1G(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1))
+                        call filter1dim(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1), skip_g=params%g, sampling=1)
 
                         ! fill upsampling buffer for high-pass filter: every second point
                         buffer3 = 0.0_rk
                         buffer3(2:ny:2) = u_wc(ix, n(2)+1:2*n(2), iz, ic)
-                        call filter1G(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1))
+                        call filter1dim(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1), skip_g=params%g, sampling=1)
 
                         u_wc(ix, :, iz, ic) = buffer2 + buffer1
                     enddo
@@ -2776,12 +2296,12 @@ contains
                         ! apply low-pass filter to upsampled signal
                         buffer3 = 0.0_rk
                         buffer3(2:ny:2) = u_wc(ix, iy, 1:n(3), ic)
-                        call filter1G(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1))
+                        call filter1dim(params, buffer3, buffer1, params%HR, lbound(params%HR,dim=1), ubound(params%HR,dim=1), skip_g=params%g, sampling=1)
 
                         ! fill upsampling buffer for high-pass filter: every second point
                         buffer3 = 0.0_rk
                         buffer3(2:ny:2) = u_wc(ix, iy, n(3)+1:2*n(3), ic)
-                        call filter1G(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1))
+                        call filter1dim(params, buffer3, buffer2, params%GR, lbound(params%GR,dim=1), ubound(params%GR,dim=1), skip_g=params%g, sampling=1)
 
                         u_wc(ix, iy, :, ic) = buffer2 + buffer1
                     enddo

--- a/LIB/fortran.mk
+++ b/LIB/fortran.mk
@@ -245,7 +245,8 @@ $(OBJDIR)/module_timing.o: module_timing.f90
 $(OBJDIR)/module_ini_files_parser_mpi.o: module_ini_files_parser_mpi.f90 $(OBJDIR)/module_globals.o $(OBJDIR)/module_ini_files_parser.o
 	$(FC) $(FFLAGS) -c -o $@ $< $(LDFLAGS)
 
-$(OBJDIR)/module_wavelets.o: module_wavelets.f90 $(OBJDIR)/module_params.o $(OBJDIR)/module_globals.o
+$(OBJDIR)/module_wavelets.o: module_wavelets.f90 $(OBJDIR)/module_params.o $(OBJDIR)/module_globals.o \
+	conversion_routines.f90
 	$(FC) $(FFLAGS) -c -o $@ $< $(LDFLAGS)
 
 $(OBJDIR)/module_physics_metamodule.o: module_physics_metamodule.f90 $(OBJDIR)/module_globals.o \
@@ -261,7 +262,7 @@ $(OBJDIR)/module_initialization.o: module_initialization.f90 $(OBJDIR)/module_pa
 	$(FC) $(FFLAGS) -c -o $@ $< $(LDFLAGS)
 
 $(OBJDIR)/module_mpi.o: module_mpi.f90 $(OBJDIR)/module_params.o $(OBJDIR)/module_timing.o $(OBJDIR)/module_wavelets.o \
-	$(OBJDIR)/module_treelib.o blocks_per_mpirank.f90 reset_ghost_nodes.f90 synchronize_lgt_data.f90 \
+	$(OBJDIR)/module_treelib.o $(OBJDIR)/module_forestMetaData.o blocks_per_mpirank.f90 reset_ghost_nodes.f90 synchronize_lgt_data.f90 \
 	restrict_predict_data.f90 calc_data_bounds.f90 synchronize_ghosts_generic.f90 sync_ghosts_symmetry_condition.f90 reconstruction_step.f90 \
 	xfer_block_data.f90
 	$(FC) $(FFLAGS) -c -o $@ $< $(LDFLAGS)


### PR DESCRIPTION
- reduction techniques will be applied within the filtering loops already
- this affects the forwards wavelet decomposition and the filtering for the second sync stage
- also we ignore some boundary points if they never will be needed filtered
- corrected the drawings for blockFilterXYZ_ functions so that they reflect what is actually happening correctly
- outsourced some routines from wavelet module to make it more clear
- timing for each syncing stage
- ability for sync_ghost restriction to be applied patch-wise or block-wise, did some tests and its a large DEPENDS, let's discuss this soon
- I expect a performance gain, especially for larger stencils, looking especially at you there, CDF44, sync2 stage ~50% and FWT ~75% of previous times in blob3D_CDF44 test